### PR TITLE
refactor: replace clickable divs with buttons

### DIFF
--- a/bnkaraoke.web/src/components/GlobalQueuePanel.css
+++ b/bnkaraoke.web/src/components/GlobalQueuePanel.css
@@ -38,6 +38,10 @@
   background: rgba(0, 0, 0, 0.3);
   border-radius: 4px;
   cursor: pointer;
+  border: none;
+  width: 100%;
+  text-align: left;
+  display: block;
 }
 
 .queue-item-main {

--- a/bnkaraoke.web/src/components/GlobalQueuePanel.tsx
+++ b/bnkaraoke.web/src/components/GlobalQueuePanel.tsx
@@ -75,7 +75,8 @@ const GlobalQueuePanel: React.FC<GlobalQueuePanelProps> = ({
                   status: 'unknown',
                 };
                 return (
-                  <div
+                  <button
+                    type="button"
                     key={queueItem.queueId}
                     className={`queue-song ${queueItem.isCurrentlyPlaying ? 'now-playing' : ''} ${queueItem.requestorUserName === userName ? 'user-song' : ''}`}
                     onClick={() => song && handleGlobalQueueItemClick(song)}
@@ -91,7 +92,7 @@ const GlobalQueuePanel: React.FC<GlobalQueuePanelProps> = ({
                         Requested by: {queueItem.requestorFullName || queueItem.requestorUserName || 'Unknown'}
                       </span>
                     </div>
-                  </div>
+                  </button>
                 );
               })}
             </div>

--- a/bnkaraoke.web/src/components/Modals.css
+++ b/bnkaraoke.web/src/components/Modals.css
@@ -52,6 +52,11 @@
   padding: 10px;
   border-bottom: 1px solid #e5e7eb;
   cursor: pointer;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+  display: block;
 }
 
 .song-card:hover {

--- a/bnkaraoke.web/src/components/Modals.tsx
+++ b/bnkaraoke.web/src/components/Modals.tsx
@@ -129,7 +129,8 @@ const Modals: React.FC<ModalsProps> = ({
             ) : (
               <div className="song-list">
                 {songs.map(song => (
-                  <div
+                  <button
+                    type="button"
                     key={song.id}
                     className="song-card"
                     onClick={() => {
@@ -156,7 +157,7 @@ const Modals: React.FC<ModalsProps> = ({
                         )}
                       </div>
                     )}
-                  </div>
+                  </button>
                 ))}
               </div>
             )}
@@ -191,7 +192,8 @@ const Modals: React.FC<ModalsProps> = ({
             ) : (
               <div className="song-list">
                 {spotifySongs.map(song => (
-                  <div
+                  <button
+                    type="button"
                     key={song.id}
                     className="song-card"
                     onClick={() => handleSpotifySongSelect(song)}
@@ -199,7 +201,7 @@ const Modals: React.FC<ModalsProps> = ({
                   >
                     <div className="song-title">{song.title}</div>
                     <div className="song-artist">({song.artist || 'Unknown Artist'})</div>
-                  </div>
+                  </button>
                 ))}
               </div>
             )}

--- a/bnkaraoke.web/src/components/QueuePanel.css
+++ b/bnkaraoke.web/src/components/QueuePanel.css
@@ -15,6 +15,11 @@
   padding: 10px;
   border-bottom: 1px solid #eee;
   cursor: pointer;
+  border: none;
+  width: 100%;
+  text-align: left;
+  display: block;
+  background: none;
 }
 
 .queue-item:hover {

--- a/bnkaraoke.web/src/components/QueuePanel.tsx
+++ b/bnkaraoke.web/src/components/QueuePanel.tsx
@@ -99,13 +99,14 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
                       disabled={!enableDragAndDrop || item.isCurrentlyPlaying}
                       className={item.isCurrentlyPlaying ? 'now-playing' : ''}
                     >
-                      <div
+                      <button
+                        type="button"
                         className="queue-item"
                         onClick={() => handleQueueItemClick(song, item.queueId, item.eventId)}
                       >
                         <span>{song.title} - {song.artist}</span>
                         {item.isCurrentlyPlaying && <span className="now-playing-label"> (Now Playing)</span>}
-                      </div>
+                      </button>
                     </SortableItem>
                   );
                 })}

--- a/bnkaraoke.web/src/components/SongDetailsModal.css
+++ b/bnkaraoke.web/src/components/SongDetailsModal.css
@@ -111,6 +111,10 @@
   border-radius: 4px;
   margin-bottom: 5px;
   color: #1e293b;
+  border: none;
+  width: 100%;
+  text-align: left;
+  display: block;
 }
 .event-item:hover {
   background: #f1f5f9;

--- a/bnkaraoke.web/src/components/SongDetailsModal.tsx
+++ b/bnkaraoke.web/src/components/SongDetailsModal.tsx
@@ -416,7 +416,8 @@ const SongDetailsModal: React.FC<SongDetailsModalProps> = ({
               {upcomingEvents
                 .filter(event => event.status.toLowerCase() === "upcoming")
                 .map(event => (
-                  <div
+                  <button
+                    type="button"
                     key={event.eventId}
                     className="event-item"
                     onClick={() => {
@@ -429,7 +430,7 @@ const SongDetailsModal: React.FC<SongDetailsModalProps> = ({
                     }}
                   >
                     {event.status}: {event.eventCode} ({event.scheduledDate})
-                  </div>
+                  </button>
                 ))}
             </div>
             <div className="modal-footer">

--- a/bnkaraoke.web/src/pages/Dashboard.tsx
+++ b/bnkaraoke.web/src/pages/Dashboard.tsx
@@ -551,10 +551,10 @@ const Dashboard: React.FC = () => {
     setSelectedSong(song);
   }, [setSelectedSong]);
 
-  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
-    console.log("[DRAG] Debug: handleDragEnd triggered with event:", event);
-    console.log("[DRAG] Active and Over IDs:", { activeId: event.active.id, overId: event.over?.id });
-    const { active, over } = event;
+  const handleDragEnd = useCallback(async (dragEvent: DragEndEvent) => {
+    console.log("[DRAG] Debug: handleDragEnd triggered with event:", dragEvent);
+    console.log("[DRAG] Active and Over IDs:", { activeId: dragEvent.active.id, overId: dragEvent.over?.id });
+    const { active, over } = dragEvent;
     if (!active || !over || active.id === over.id) {
       console.log("[DRAG] No action needed - same position or invalid drag");
       return;

--- a/bnkaraoke.web/src/pages/ExploreSongs.css
+++ b/bnkaraoke.web/src/pages/ExploreSongs.css
@@ -150,11 +150,20 @@
   padding: 10px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   cursor: pointer;
+  border: none;
+  text-align: left;
+  width: 100%;
+  display: block;
 }
 
 .song-info {
   display: flex;
   flex-direction: column;
+  border: none;
+  background: none;
+  text-align: left;
+  width: 100%;
+  cursor: pointer;
 }
 
 .song-title {

--- a/bnkaraoke.web/src/pages/ExploreSongs.tsx
+++ b/bnkaraoke.web/src/pages/ExploreSongs.tsx
@@ -977,14 +977,15 @@ const ExploreSongs: React.FC = () => {
               <p>Loading...</p>
             ) : browseSongs.length === 0 ? (
               <p>No songs found</p>
-            ) : (
-              browseSongs.map(song => (
-                <div key={song.id} className="song-card">
-                  <div
-                    className="song-info"
-                    onClick={() => setSelectedSong(song)}
-                    onTouchEnd={() => setSelectedSong(song)}
-                  >
+              ) : (
+                browseSongs.map(song => (
+                  <div key={song.id} className="song-card">
+                    <button
+                      type="button"
+                      className="song-info"
+                      onClick={() => setSelectedSong(song)}
+                      onTouchEnd={() => setSelectedSong(song)}
+                    >
                     <div className="song-title">{song.title}</div>
                     <div className="song-artist">({song.artist || 'Unknown Artist'})</div>
                     <div className="song-status">
@@ -997,10 +998,10 @@ const ExploreSongs: React.FC = () => {
                       {song.status?.toLowerCase() === 'unavailable' && (
                         <span className="song-status-badge unavailable">Unavailable</span>
                       )}
-                    </div>
+                      </div>
+                    </button>
                   </div>
-                </div>
-              ))
+                ))
             )}
           </div>
           {totalPages > 1 && (
@@ -1072,17 +1073,18 @@ const ExploreSongs: React.FC = () => {
                 <p className="modal-text">No songs found on Spotify. Try a different search.</p>
               ) : (
                 <div className="song-list">
-                  {spotifySongs.map(song => (
-                    <div
-                      key={song.id}
-                      className="song-card"
-                      onClick={() => handleSpotifySongSelect(song)}
-                      onTouchEnd={() => handleSpotifySongSelect(song)}
-                    >
-                      <div className="song-title">{song.title}</div>
-                      <div className="song-artist">({song.artist || 'Unknown Artist'})</div>
-                    </div>
-                  ))}
+                    {spotifySongs.map(song => (
+                      <button
+                        type="button"
+                        key={song.id}
+                        className="song-card"
+                        onClick={() => handleSpotifySongSelect(song)}
+                        onTouchEnd={() => handleSpotifySongSelect(song)}
+                      >
+                        <div className="song-title">{song.title}</div>
+                        <div className="song-artist">({song.artist || 'Unknown Artist'})</div>
+                      </button>
+                    ))}
                 </div>
               )}
               <div className="modal-actions">


### PR DESCRIPTION
## Summary
- Replace interactive divs with semantic buttons across queue, modal, and song views
- Adjust associated CSS to keep original appearance while removing default button styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a33c2d79708323830becc78546010e