### PR TITLE
fix: allow admin dropdown to display fully and relax dev CORS

### DIFF
--- a/BNKaraoke.Api/Program.cs
+++ b/BNKaraoke.Api/Program.cs
@@ -184,16 +184,10 @@ builder.Services.AddCors(options =>
     var isDevelopment = builder.Environment.IsDevelopment();
     if (isDevelopment)
     {
-        var allowedOrigins = builder.Configuration.GetSection("AllowedOrigins").Get<string[]>();
-        if (allowedOrigins == null || allowedOrigins.Length == 0)
-        {
-            Log.Error("AllowedOrigins is missing or empty in configuration.");
-            throw new InvalidOperationException("AllowedOrigins is missing or empty in configuration.");
-        }
-        Log.Information("CORS configured with AllowedOrigins: {Origins}", string.Join(", ", allowedOrigins));
+        Log.Information("CORS configured to allow any origin in development");
         options.AddPolicy("AllowNetwork", policy =>
         {
-            policy.WithOrigins(allowedOrigins)
+            policy.SetIsOriginAllowed(_ => true)
                   .AllowAnyMethod()
                   .AllowAnyHeader()
                   .AllowCredentials();

--- a/bnkaraoke.web/src/components/Header.css
+++ b/bnkaraoke.web/src/components/Header.css
@@ -7,7 +7,7 @@
   box-shadow: 0 0 20px rgba(34, 211, 238, 0.5);
   color: white;
   height: auto; /* Content-driven height */
-  overflow-y: auto; /* Scroll if needed */
+  overflow: visible; /* Allow dropdowns to extend beyond header */
   position: relative;
   z-index: 10;
   padding-top: env(safe-area-inset-top, 10px); /* Account for notches */
@@ -249,6 +249,17 @@
 
 .admin-dropdown {
   position: relative;
+}
+
+.admin-dropdown .event-dropdown-menu {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  right: auto;
+  max-height: 80vh;
+  max-width: 90vw;
+  overflow-y: auto;
 }
 
 .dropdown-toggle {

--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -12,7 +12,7 @@ const Header: React.FC = memo(() => {
   const navigate = useNavigate();
   const location = useLocation();
   const [isMobile, setIsMobile] = useState(window.matchMedia("(max-width: 1024px)").matches); // Adjusted for iPad
-  const { currentEvent, setCurrentEvent, checkedIn, setCheckedIn, isCurrentEventLive, setIsCurrentEventLive, isOnBreak, setIsOnBreak, liveEvents, setLiveEvents, upcomingEvents, setUpcomingEvents, selectionRequired, noEvents } = useEventContext();
+  const { currentEvent, setCurrentEvent, checkedIn, setCheckedIn, isCurrentEventLive, setIsCurrentEventLive, isOnBreak, setIsOnBreak, liveEvents, setLiveEvents, upcomingEvents, setUpcomingEvents, noEvents } = useEventContext();
   const [firstName, setFirstName] = useState(localStorage.getItem("firstName") || "");
   const [lastName, setLastName] = useState(localStorage.getItem("lastName") || "");
   const [roles, setRoles] = useState<string[]>(JSON.parse(localStorage.getItem("roles") || "[]"));
@@ -637,8 +637,20 @@ const Header: React.FC = memo(() => {
                 <div className="event-dropdown join-event-dropdown" ref={eventDropdownRef}>
                   <button
                     className="check-in-button"
-                    onClick={() => setIsEventModalOpen(true)} // Open modal for event selection
-                    onTouchStart={() => setIsEventModalOpen(true)} // Open modal for event selection
+                    onClick={() => {
+                      if (liveEvents.length === 1) {
+                        handleCheckIn(liveEvents[0]);
+                      } else {
+                        setIsEventModalOpen(true);
+                      }
+                    }}
+                    onTouchStart={() => {
+                      if (liveEvents.length === 1) {
+                        handleCheckIn(liveEvents[0]);
+                      } else {
+                        setIsEventModalOpen(true);
+                      }
+                    }}
                     disabled={noEvents || (liveEvents.length > 1 ? false : liveEvents.length === 0)}
                     aria-label="Join Live Event"
                   >
@@ -684,7 +696,7 @@ const Header: React.FC = memo(() => {
           </div>
         </div>
       )}
-      {isEventModalOpen && (selectionRequired || liveEvents.length === 0) && (
+      {isEventModalOpen && liveEvents.length > 1 && (
         <div className="confirmation-modal">
           <div className="confirmation-content" ref={eventModalRef}>
             <h3>Select Event to Join</h3>


### PR DESCRIPTION
## Summary
- allow header dropdowns to overflow so the Admin menu displays completely
- center the Admin menu for easier reading and interaction
- allow any origin for CORS in development to support testing on varying networks
- fix mobile join event by auto-checking single events and showing selection when multiple events exist

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `CI=true npm test --prefix bnkaraoke.web -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a87fa5172c832395a189108340e8e8