### PR TITLE
Use dynamic API base URL

### DIFF
--- a/bnkaraoke.web/src/context/EventContext.tsx
+++ b/bnkaraoke.web/src/context/EventContext.tsx
@@ -31,8 +31,6 @@ interface EventContextType {
 
 const EventContext = createContext<EventContextType | undefined>(undefined);
 
-const API_BASE_URL = process.env.NODE_ENV === 'production' ? 'https://api.bnkaraoke.com' : 'http://localhost:7290';
-
 export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -176,8 +174,8 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
     setNoEvents(false);
 
     try {
-      console.log("[EVENT_CONTEXT] Fetching events from:", `${API_BASE_URL}/api/events`);
-      const response = await fetch(`${API_BASE_URL}/api/events`, {
+      console.log("[EVENT_CONTEXT] Fetching events from:", API_ROUTES.EVENTS);
+      const response = await fetch(API_ROUTES.EVENTS, {
         headers: { Authorization: `Bearer ${token}` },
       });
       const responseText = await response.text();

--- a/bnkaraoke.web/src/hooks/useSignalR.ts
+++ b/bnkaraoke.web/src/hooks/useSignalR.ts
@@ -2,7 +2,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { HubConnectionBuilder, HubConnectionState, HubConnection, LogLevel, HttpTransportType, HttpClient, HttpRequest, HttpResponse } from '@microsoft/signalr';
 import { EventQueueItem, Song } from '../types';
-import { API_ROUTES } from '../config/apiConfig';
+import API_BASE_URL, { API_ROUTES } from '../config/apiConfig';
 
 interface EventQueueDto {
   queueId: number;
@@ -38,9 +38,8 @@ interface SignalRReturn {
   serverAvailable: boolean;
 }
 
-const API_BASE_URL = process.env.NODE_ENV === 'production' ? 'https://api.bnkaraoke.com' : 'http://localhost:7290';
-const WS_BASE_URL = process.env.NODE_ENV === 'production' ? 'wss://api.bnkaraoke.com' : 'ws://localhost:7290';
-const NEGOTIATE_URL = process.env.NODE_ENV === 'production' ? 'https://api.bnkaraoke.com/hubs/karaoke-dj/negotiate' : 'http://localhost:7290/hubs/karaoke-dj/negotiate';
+const WS_BASE_URL = API_BASE_URL.replace(/^http/, 'ws');
+const NEGOTIATE_URL = `${API_BASE_URL}/hubs/karaoke-dj/negotiate`;
 const HEALTH_CHECK_URL = `${API_BASE_URL}/api/events/health`;
 
 const useSignalR = ({

--- a/bnkaraoke.web/src/pages/AddRequests.tsx
+++ b/bnkaraoke.web/src/pages/AddRequests.tsx
@@ -8,7 +8,6 @@ import { API_ROUTES } from '../config/apiConfig';
 import { SpotifySong, Song } from '../types';
 import Modals from '../components/Modals';
 
-const API_BASE_URL = process.env.NODE_ENV === 'production' ? 'https://api.bnkaraoke.com' : 'http://localhost:7290';
 
 interface Requestor {
   userName: string;
@@ -186,7 +185,7 @@ const AddRequests: React.FC = () => {
     }
     try {
       console.log("[ADD_REQUESTS] Fetching requestors from: /api/auth/users");
-      const response = await fetch(`${API_BASE_URL}/api/auth/users`, {
+      const response = await fetch(API_ROUTES.USERS, {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- Replace hardcoded localhost URLs with shared API_ROUTES in the event context
- Derive SignalR websocket and health endpoints from the shared API base
- Update AddRequests to call user endpoint using dynamic API_ROUTES

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a88eb620fc8323ba32f464b4632c8a