### PR TITLE
Ignore Brave translation errors on mobile login

### DIFF
--- a/bnkaraoke.web/src/App.tsx
+++ b/bnkaraoke.web/src/App.tsx
@@ -170,11 +170,20 @@ const App: React.FC = () => {
       const originalConsoleError = console.error;
       console.error = (...args) => {
         const errorMessage = args.join(' ');
+        // Ignore noisy translation errors that appear on mobile Brave
+        if (errorMessage && errorMessage.includes('translateDisabled')) {
+          return;
+        }
         setConsoleErrors((prev) => [...prev, `${new Date().toISOString()}: ${errorMessage}`]);
         originalConsoleError(...args);
       };
       window.onerror = (message, source, lineno) => {
-        setConsoleErrors((prev) => [...prev, `${new Date().toISOString()}: Error: ${message} at ${source}:${lineno}`]);
+        const msg = String(message);
+        // Skip logging of translation-related errors that Brave injects
+        if (msg.includes('translateDisabled')) {
+          return true;
+        }
+        setConsoleErrors((prev) => [...prev, `${new Date().toISOString()}: Error: ${msg} at ${source}:${lineno}`]);
         return true;
       };
       const originalFetch = window.fetch;


### PR DESCRIPTION
## Summary
- Ignore `translateDisabled` errors injected by Brave mobile in console and window error handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a89241bdcc8323bd4ec9f1394e1656