### PR TITLE
Refine mobile header layout

### DIFF
--- a/bnkaraoke.web/src/components/Header.css
+++ b/bnkaraoke.web/src/components/Header.css
@@ -18,6 +18,22 @@
   padding: 6px 10px; /* Match mobile padding */
 }
 
+.mobile-header .header-user {
+  font-size: 1em;
+}
+
+.mobile-header .admin-dropdown,
+.mobile-header .header-user,
+.mobile-header .mobile-actions {
+  width: 100%;
+}
+
+.mobile-header .mobile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
 .header-main {
   display: flex;
   justify-content: flex-start; /* Align items at the top */


### PR DESCRIPTION
## Summary
- Show event name in mobile greeting and render mobile-only action buttons
- Style mobile header for stacked layout and smaller greeting text

## Testing
- `CI=true npm test --prefix bnkaraoke.web`

------
https://chatgpt.com/codex/tasks/task_e_68a89dd0b1188323960e46b97c004fab