### PR TITLE
Fix DJ queue updates and requestor display

### DIFF
--- a/BNKaraoke.DJ/Models/QueueEntry.cs
+++ b/BNKaraoke.DJ/Models/QueueEntry.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Serilog;
+using System.Text.Json.Serialization;
 
 namespace BNKaraoke.DJ.Models
 {
@@ -101,7 +102,22 @@ namespace BNKaraoke.DJ.Models
             set => SetProperty(ref _songArtist, value);
         }
 
+        [JsonIgnore]
         public string? RequestorDisplayName
+        {
+            get => _requestorDisplayName;
+            set => SetProperty(ref _requestorDisplayName, value);
+        }
+
+        [JsonPropertyName("requestorFullName")]
+        public string? RequestorFullName
+        {
+            get => _requestorDisplayName;
+            set => SetProperty(ref _requestorDisplayName, value);
+        }
+
+        [JsonPropertyName("requestorDisplayName")]
+        public string? RequestorDisplayNameJson
         {
             get => _requestorDisplayName;
             set => SetProperty(ref _requestorDisplayName, value);

--- a/BNKaraoke.DJ/Models/QueueUpdateMessage.cs
+++ b/BNKaraoke.DJ/Models/QueueUpdateMessage.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace BNKaraoke.DJ.Models
+{
+    public class QueueUpdateMessage
+    {
+        public int QueueId { get; set; }
+        public int EventId { get; set; }
+        public string Action { get; set; } = string.Empty;
+        public string? YouTubeUrl { get; set; }
+        public string? HoldReason { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- Align DJ console SignalR client with server QueueUpdated message
- Map requestor full name from API to queue entries
- Add QueueUpdateMessage model for SignalR events

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa96689c8c832386b6baff0b7f9381