### PR TITLE
Pass event id to SignalR and surface video URLs

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -1412,6 +1412,7 @@ namespace BNKaraoke.Api.Controllers
         public int SongId { get; set; }
         public string SongTitle { get; set; } = string.Empty;
         public string SongArtist { get; set; } = string.Empty;
+        public string? YouTubeUrl { get; set; }
         public string RequestorUserName { get; set; } = string.Empty;
         public string RequestorFullName { get; set; } = string.Empty;
         public List<string> Singers { get; set; } = new List<string>();

--- a/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
+++ b/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
@@ -464,9 +464,9 @@ namespace BNKaraoke.Api.Controllers
                 }).ToList();
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDtos, "Reordered");
-                _logger.LogInformation("Sent QueueUpdated for EventId={EventId}, Action=Reordered, QueueCount={QueueCount} in {TotalElapsedMilliseconds} ms", eventId, queueDtos.Count, sw.ElapsedMilliseconds);
+                _logger.LogInformation($"Sent QueueUpdated for EventId={eventId}, Action=Reordered, QueueCount={queueDtos.Count} in {sw.ElapsedMilliseconds} ms");
 
-                _logger.LogInformation("Reordered queue for EventId: {EventId} in {TotalElapsedMilliseconds} ms", eventId, sw.ElapsedMilliseconds);
+                _logger.LogInformation($"Reordered queue for EventId: {eventId} in {sw.ElapsedMilliseconds} ms");
                 return Ok(new { message = "Queue reordered" });
             }
             catch (Exception ex)
@@ -613,10 +613,9 @@ namespace BNKaraoke.Api.Controllers
                 }).ToList();
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDtos, "Reordered");
-                _logger.LogInformation("Sent QueueUpdated for EventId={EventId}, Action=Reordered, QueueCount={QueueCount} in {TotalElapsedMilliseconds} ms", eventId, queueDtos.Count, sw.ElapsedMilliseconds);
+                _logger.LogInformation($"Sent QueueUpdated for EventId={eventId}, Action=Reordered, QueueCount={queueDtos.Count} in {sw.ElapsedMilliseconds} ms");
 
-                _logger.LogInformation("Personal queue reordered for EventId: {EventId}, User: {User}, NewPositions={NewPositions} in {TotalElapsedMilliseconds} ms",
-                    eventId, userName, JsonSerializer.Serialize(queueDtos.Where(q => q.RequestorUserName == userName).Select(q => new { q.QueueId, q.Position })), sw.ElapsedMilliseconds);
+                _logger.LogInformation($"Personal queue reordered for EventId: {eventId}, User: {userName}, NewPositions={JsonSerializer.Serialize(queueDtos.Where(q => q.RequestorUserName == userName).Select(q => new { q.QueueId, q.Position }))} in {sw.ElapsedMilliseconds} ms");
 
                 return Ok(new { message = "Personal Queue reordered", queue = queueDtos.OrderBy(q => q.Position) });
             }

--- a/BNKaraoke.DJ/Services/SignalRService.cs
+++ b/BNKaraoke.DJ/Services/SignalRService.cs
@@ -52,7 +52,7 @@ namespace BNKaraoke.DJ.Services
 
             _currentEventId = eventId;
             string apiUrl = _settingsService.Settings.ApiUrl?.TrimEnd('/') ?? "http://localhost:7290";
-            string hubUrl = $"{apiUrl}{HubPath}";
+            string hubUrl = $"{apiUrl}{HubPath}?eventId={eventId}";
 
             Log.Information("[SIGNALR] Settings: ApiUrl={ApiUrl} for EventId={EventId}", apiUrl, eventId);
             Log.Information("[SIGNALR] Constructing hub URL: {HubUrl} for EventId={EventId}", hubUrl, eventId);

--- a/bnkaraoke.web/src/hooks/useSignalR.ts
+++ b/bnkaraoke.web/src/hooks/useSignalR.ts
@@ -10,6 +10,7 @@ interface EventQueueDto {
   songId: number;
   songTitle: string;
   songArtist: string;
+  youTubeUrl?: string;
   requestorUserName: string;
   requestorFullName: string | null;
   singers: string[];
@@ -181,6 +182,7 @@ const useSignalR = ({
       isOnBreak: dto.isOnBreak,
       songTitle: dto.songTitle,
       songArtist: dto.songArtist,
+      youTubeUrl: dto.youTubeUrl,
     };
   };
 

--- a/bnkaraoke.web/src/types.ts
+++ b/bnkaraoke.web/src/types.ts
@@ -65,6 +65,7 @@ export interface EventQueueItemResponse {
   songId: number;
   songTitle: string;
   songArtist: string;
+  youTubeUrl?: string;
   requestorUserName: string;
   requestorDisplayName: string;
   singers: string;
@@ -99,6 +100,7 @@ export interface EventQueueItem {
   isUpNext: boolean;
   songTitle?: string;
   songArtist?: string;
+  youTubeUrl?: string;
 }
 
 export interface AttendanceAction {


### PR DESCRIPTION
## Summary
- Send the event id when the DJ console connects to the SignalR hub
- Include YouTube URL in web SignalR DTOs and map it onto queue items

## Testing
- `dotnet build` *(command not found)*
- `apt-get update` *(403 Forbidden from proxy)*
- `cd bnkaraoke.web && CI=true npm test --silent` *(no tests found, exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa89715a48323ba01fcfc1ab343d8