### PR TITLE
Enable DJ console seek and stop controls

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -33,9 +33,6 @@ namespace BNKaraoke.DJ.ViewModels
         private double _pendingSeekPosition;
         private double _lastPosition;
 
-        [ObservableProperty]
-        private double _sliderPosition;
-
         public void SetWarningMessage(string message)
         {
             if (_isDisposing) return;
@@ -129,11 +126,11 @@ namespace BNKaraoke.DJ.ViewModels
                         TimeRemainingSeconds = 0;
                         TimeRemaining = "0:00";
                         CurrentVideoPosition = "--:--";
-                        SliderPosition = 0;
+                        SongPosition = 0;
                         _lastPosition = 0;
                         SongDuration = TimeSpan.Zero;
                         _totalDuration = null;
-                        OnPropertyChanged(nameof(SliderPosition));
+                        OnPropertyChanged(nameof(SongPosition));
                         OnPropertyChanged(nameof(CurrentVideoPosition));
                         OnPropertyChanged(nameof(TimeRemaining));
                         OnPropertyChanged(nameof(TimeRemainingSeconds));
@@ -169,10 +166,10 @@ namespace BNKaraoke.DJ.ViewModels
                             if (Math.Abs(newPosition - _lastPosition) > 1.0)
                             {
                                 CurrentVideoPosition = currentTime.ToString(@"m\:ss");
-                                SliderPosition = newPosition;
+                                SongPosition = newPosition;
                                 _lastPosition = newPosition;
-                                Log.Verbose("[DJSCREEN] Updated SliderPosition to {Position}", newPosition);
-                                OnPropertyChanged(nameof(SliderPosition));
+                                Log.Verbose("[DJSCREEN] Updated SongPosition to {Position}", newPosition);
+                                OnPropertyChanged(nameof(SongPosition));
                                 OnPropertyChanged(nameof(CurrentVideoPosition));
                             }
                         }
@@ -268,7 +265,9 @@ namespace BNKaraoke.DJ.ViewModels
                         long seekTime = (long)(_pendingSeekPosition * 1000);
                         _videoPlayerWindow.MediaPlayer.Time = seekTime;
                         _lastPosition = _pendingSeekPosition;
+                        SongPosition = _pendingSeekPosition;
                         CurrentVideoPosition = TimeSpan.FromSeconds(_pendingSeekPosition).ToString(@"m\:ss");
+                        OnPropertyChanged(nameof(SongPosition));
                         OnPropertyChanged(nameof(CurrentVideoPosition));
                         if (_wasPlaying && _videoPlayerWindow.MediaPlayer.State != VLCState.Playing)
                         {
@@ -307,10 +306,10 @@ namespace BNKaraoke.DJ.ViewModels
                             var newPosition = e.Position * _totalDuration?.TotalSeconds ?? 0;
                             if (Math.Abs(newPosition - _lastPosition) > 1.0)
                             {
-                                SliderPosition = newPosition;
+                                SongPosition = newPosition;
                                 _lastPosition = newPosition;
                                 CurrentVideoPosition = TimeSpan.FromSeconds(newPosition).ToString(@"m\:ss");
-                                OnPropertyChanged(nameof(SliderPosition));
+                                OnPropertyChanged(nameof(SongPosition));
                                 OnPropertyChanged(nameof(CurrentVideoPosition));
                                 Log.Verbose("[DJSCREEN] VLC PositionChanged: {Position}", newPosition);
                             }
@@ -345,7 +344,7 @@ namespace BNKaraoke.DJ.ViewModels
                 OnPropertyChanged(nameof(SelectedQueueEntry));
                 OnPropertyChanged(nameof(IsPlaying));
                 OnPropertyChanged(nameof(IsVideoPaused));
-                OnPropertyChanged(nameof(SliderPosition));
+                OnPropertyChanged(nameof(SongPosition));
                 OnPropertyChanged(nameof(CurrentVideoPosition));
                 OnPropertyChanged(nameof(TimeRemaining));
                 OnPropertyChanged(nameof(TimeRemainingSeconds));
@@ -362,7 +361,7 @@ namespace BNKaraoke.DJ.ViewModels
             {
                 IsPlaying = false;
                 IsVideoPaused = false;
-                SliderPosition = 0;
+                SongPosition = 0;
                 _lastPosition = 0;
                 CurrentVideoPosition = "--:--";
                 TimeRemainingSeconds = 0;
@@ -652,7 +651,7 @@ namespace BNKaraoke.DJ.ViewModels
                     SelectedQueueEntry = targetEntry;
                     IsPlaying = true;
                     IsVideoPaused = false;
-                    SliderPosition = 0;
+                    SongPosition = 0;
                     _lastPosition = 0;
                     CurrentVideoPosition = "0:00";
                     TimeRemainingSeconds = 0;
@@ -765,6 +764,72 @@ namespace BNKaraoke.DJ.ViewModels
                     Log.Information("[DJSCREEN] UI reset after playback failure");
                 });
                 _isInitialPlayback = false;
+            }
+        }
+
+        [RelayCommand]
+        private async Task StopRestartAsync()
+        {
+            Log.Information("[DJSCREEN] Stop/Restart command invoked");
+            if (_isDisposing || _videoPlayerWindow?.MediaPlayer == null || PlayingQueueEntry == null)
+            {
+                return;
+            }
+
+            try
+            {
+                if (!IsVideoPaused)
+                {
+                    _videoPlayerWindow.StopVideo();
+                    if (_updateTimer != null)
+                    {
+                        _updateTimer.Stop();
+                    }
+                    if (!string.IsNullOrEmpty(_currentEventId))
+                    {
+                        await _apiService.StopAsync(_currentEventId, PlayingQueueEntry.QueueId.ToString());
+                    }
+                    await Application.Current.Dispatcher.InvokeAsync(() =>
+                    {
+                        IsPlaying = false;
+                        IsVideoPaused = true;
+                        SongPosition = 0;
+                        _lastPosition = 0;
+                        CurrentVideoPosition = "0:00";
+                        StopRestartButtonColor = "#FF0000";
+                        OnPropertyChanged(nameof(SongPosition));
+                        OnPropertyChanged(nameof(CurrentVideoPosition));
+                        NotifyAllProperties();
+                    });
+                }
+                else
+                {
+                    _videoPlayerWindow.MediaPlayer.Time = 0;
+                    _videoPlayerWindow.MediaPlayer.Play();
+                    if (_updateTimer == null)
+                    {
+                        _updateTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+                        _updateTimer.Tick += UpdateTimer_Tick;
+                        _updateTimer.Start();
+                    }
+                    await Application.Current.Dispatcher.InvokeAsync(() =>
+                    {
+                        IsVideoPaused = false;
+                        IsPlaying = true;
+                        SongPosition = 0;
+                        _lastPosition = 0;
+                        CurrentVideoPosition = "0:00";
+                        StopRestartButtonColor = "#22d3ee";
+                        OnPropertyChanged(nameof(SongPosition));
+                        OnPropertyChanged(nameof(CurrentVideoPosition));
+                        NotifyAllProperties();
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[DJSCREEN] Failed to stop/restart song: {Message}", ex.Message);
+                await SetWarningMessageAsync($"Failed to stop/restart: {ex.Message}");
             }
         }
 
@@ -900,7 +965,7 @@ namespace BNKaraoke.DJ.ViewModels
                     SelectedQueueEntry = targetEntry;
                     IsPlaying = true;
                     IsVideoPaused = false;
-                    SliderPosition = 0;
+                    SongPosition = 0;
                     _lastPosition = 0;
                     CurrentVideoPosition = "0:00";
                     TimeRemainingSeconds = 0;

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -295,11 +295,11 @@ namespace BNKaraoke.DJ.ViewModels
                     Log.Information("[DJSCREEN] Video playback stopped due to no valid queue entry");
                     IsPlaying = false;
                     IsVideoPaused = false;
-                    SliderPosition = 0;
+                    SongPosition = 0;
                     CurrentVideoPosition = "--:--";
                     TimeRemainingSeconds = 0;
                     TimeRemaining = "0:00";
-                    OnPropertyChanged(nameof(SliderPosition));
+                    OnPropertyChanged(nameof(SongPosition));
                     OnPropertyChanged(nameof(CurrentVideoPosition));
                     OnPropertyChanged(nameof(TimeRemaining));
                     OnPropertyChanged(nameof(TimeRemainingSeconds));
@@ -322,11 +322,11 @@ namespace BNKaraoke.DJ.ViewModels
                 targetEntry.WasSkipped = true;
                 IsPlaying = false;
                 IsVideoPaused = false;
-                SliderPosition = 0;
+                SongPosition = 0;
                 CurrentVideoPosition = "--:--";
                 TimeRemainingSeconds = 0;
                 TimeRemaining = "0:00";
-                OnPropertyChanged(nameof(SliderPosition));
+                OnPropertyChanged(nameof(SongPosition));
                 OnPropertyChanged(nameof(CurrentVideoPosition));
                 OnPropertyChanged(nameof(TimeRemaining));
                 OnPropertyChanged(nameof(TimeRemainingSeconds));

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -113,8 +113,11 @@
                             Minimum="0"
                             IsEnabled="{Binding IsPlaying}"
                             Margin="5,0"
+                            IsMoveToPointEnabled="True"
                             Thumb.DragStarted="Slider_DragStarted"
                             Thumb.DragCompleted="Slider_DragCompleted"
+                            PreviewMouseLeftButtonDown="Slider_PreviewMouseLeftButtonDown"
+                            PreviewMouseLeftButtonUp="Slider_PreviewMouseLeftButtonUp"
                             ValueChanged="Slider_ValueChanged"/>
                     <TextBlock Grid.Column="5" Grid.Row="0" Text="{Binding CurrentVideoPosition, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Left" Margin="5,15,0,5" Background="#80000000" Padding="2"/>
                     <TextBlock Grid.Column="5" Grid.Row="0" Text="{Binding SongDuration, StringFormat={}{0:m\\:ss}, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Right" Margin="0,15,5,5" Background="#80000000" Padding="2"/>

--- a/BNKaraoke.DJ/Views/DJScreen.xaml.cs
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml.cs
@@ -249,5 +249,33 @@ namespace BNKaraoke.DJ.Views
                 Log.Error("[DJSCREEN] Failed to handle slider value change: {Message}", ex.Message);
             }
         }
+
+        private void Slider_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                var viewModel = DataContext as DJScreenViewModel;
+                viewModel?.StartSeekingCommand.Execute(null);
+                Log.Information("[DJSCREEN] Slider mouse down - seeking started");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[DJSCREEN] Failed to handle slider mouse down: {Message}", ex.Message);
+            }
+        }
+
+        private void Slider_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                var viewModel = DataContext as DJScreenViewModel;
+                viewModel?.StopSeekingCommand.Execute(null);
+                Log.Information("[DJSCREEN] Slider mouse up - seeking stopped");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[DJSCREEN] Failed to handle slider mouse up: {Message}", ex.Message);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Allow users to seek by clicking or dragging with a unified SongPosition value
- Add Stop/Restart command to control playback

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aab22676bc83239f8582c57b8580a8