### PR TITLE
Fix DJ console seek slider and stop button

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -295,11 +295,11 @@ namespace BNKaraoke.DJ.ViewModels
                     Log.Information("[DJSCREEN] Video playback stopped due to no valid queue entry");
                     IsPlaying = false;
                     IsVideoPaused = false;
-                    SliderPosition = 0;
+                    SongPosition = 0;
                     CurrentVideoPosition = "--:--";
                     TimeRemainingSeconds = 0;
                     TimeRemaining = "0:00";
-                    OnPropertyChanged(nameof(SliderPosition));
+                    OnPropertyChanged(nameof(SongPosition));
                     OnPropertyChanged(nameof(CurrentVideoPosition));
                     OnPropertyChanged(nameof(TimeRemaining));
                     OnPropertyChanged(nameof(TimeRemainingSeconds));
@@ -322,11 +322,11 @@ namespace BNKaraoke.DJ.ViewModels
                 targetEntry.WasSkipped = true;
                 IsPlaying = false;
                 IsVideoPaused = false;
-                SliderPosition = 0;
+                SongPosition = 0;
                 CurrentVideoPosition = "--:--";
                 TimeRemainingSeconds = 0;
                 TimeRemaining = "0:00";
-                OnPropertyChanged(nameof(SliderPosition));
+                OnPropertyChanged(nameof(SongPosition));
                 OnPropertyChanged(nameof(CurrentVideoPosition));
                 OnPropertyChanged(nameof(TimeRemaining));
                 OnPropertyChanged(nameof(TimeRemainingSeconds));

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -113,8 +113,11 @@
                             Minimum="0"
                             IsEnabled="{Binding IsPlaying}"
                             Margin="5,0"
+                            IsMoveToPointEnabled="True"
                             Thumb.DragStarted="Slider_DragStarted"
                             Thumb.DragCompleted="Slider_DragCompleted"
+                            PreviewMouseLeftButtonDown="Slider_PreviewMouseLeftButtonDown"
+                            PreviewMouseLeftButtonUp="Slider_PreviewMouseLeftButtonUp"
                             ValueChanged="Slider_ValueChanged"/>
                     <TextBlock Grid.Column="5" Grid.Row="0" Text="{Binding CurrentVideoPosition, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Left" Margin="5,15,0,5" Background="#80000000" Padding="2"/>
                     <TextBlock Grid.Column="5" Grid.Row="0" Text="{Binding SongDuration, StringFormat={}{0:m\\:ss}, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Right" Margin="0,15,5,5" Background="#80000000" Padding="2"/>

--- a/BNKaraoke.DJ/Views/DJScreen.xaml.cs
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml.cs
@@ -234,19 +234,51 @@ namespace BNKaraoke.DJ.Views
             try
             {
                 var viewModel = DataContext as DJScreenViewModel;
-                if (viewModel != null)
-                {
-                    viewModel.SeekSongCommand.Execute(e.NewValue);
-                    Log.Information("[DJSCREEN] Slider value changed: NewValue={NewValue}", e.NewValue);
-                }
-                else
+                if (viewModel == null)
                 {
                     Log.Warning("[DJSCREEN] Slider value changed: ViewModel is null");
+                    return;
                 }
+
+                if (!viewModel.IsSeeking)
+                {
+                    return;
+                }
+
+                viewModel.SeekSongCommand.Execute(e.NewValue);
+                Log.Debug("[DJSCREEN] Slider value changed: NewValue={NewValue}", e.NewValue);
             }
             catch (Exception ex)
             {
                 Log.Error("[DJSCREEN] Failed to handle slider value change: {Message}", ex.Message);
+            }
+        }
+
+        private void Slider_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                var viewModel = DataContext as DJScreenViewModel;
+                viewModel?.StartSeekingCommand.Execute(null);
+                Log.Information("[DJSCREEN] Slider mouse down - seeking started");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[DJSCREEN] Failed to handle slider mouse down: {Message}", ex.Message);
+            }
+        }
+
+        private void Slider_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            try
+            {
+                var viewModel = DataContext as DJScreenViewModel;
+                viewModel?.StopSeekingCommand.Execute(null);
+                Log.Information("[DJSCREEN] Slider mouse up - seeking stopped");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[DJSCREEN] Failed to handle slider mouse up: {Message}", ex.Message);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Expose an `IsSeeking` flag and pause/resume playback around seek operations
- Debounce seek requests and sync the slider position with playback
- Wire seek slider and stop/restart button to view-model commands
- Guard queue color updates with a semaphore and cancellation token
- Clarify `IsSeeking` usage in code comments

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.1.83 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68aab22676bc83239f8582c57b8580a8