### PR TITLE
Limit seek logging and restore video on restart

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -26,6 +26,7 @@ namespace BNKaraoke.DJ.ViewModels
         private TimeSpan? _totalDuration;
         private bool _countdownStarted;
         private bool _isSeeking;
+        public bool IsSeeking => _isSeeking;
         private bool _isInitialPlayback;
         private bool _wasPlaying;
         private readonly object _queueLock = new();
@@ -804,8 +805,7 @@ namespace BNKaraoke.DJ.ViewModels
                 }
                 else
                 {
-                    _videoPlayerWindow.MediaPlayer.Time = 0;
-                    _videoPlayerWindow.MediaPlayer.Play();
+                    _videoPlayerWindow.RestartVideo();
                     if (_updateTimer == null)
                     {
                         _updateTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };

--- a/BNKaraoke.DJ/Views/DJScreen.xaml.cs
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml.cs
@@ -236,8 +236,11 @@ namespace BNKaraoke.DJ.Views
                 var viewModel = DataContext as DJScreenViewModel;
                 if (viewModel != null)
                 {
-                    viewModel.SeekSongCommand.Execute(e.NewValue);
-                    Log.Information("[DJSCREEN] Slider value changed: NewValue={NewValue}", e.NewValue);
+                    if (viewModel.IsSeeking)
+                    {
+                        viewModel.SeekSongCommand.Execute(e.NewValue);
+                        Log.Information("[DJSCREEN] Slider value changed: NewValue={NewValue}", e.NewValue);
+                    }
                 }
                 else
                 {

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -389,6 +389,33 @@ namespace BNKaraoke.DJ.Views
             }
         }
 
+        public void RestartVideo()
+        {
+            try
+            {
+                Log.Information("[VIDEO PLAYER] Restarting video");
+                if (MediaPlayer != null)
+                {
+                    MediaPlayer.Time = 0;
+                    VideoPlayer.Visibility = Visibility.Visible;
+                    Visibility = Visibility.Visible;
+                    Show();
+                    Activate();
+                    MediaPlayer.Play();
+                    Log.Information("[VIDEO PLAYER] Video restarted, VLC state: IsPlaying={IsPlaying}, State={State}",
+                        MediaPlayer.IsPlaying, MediaPlayer.State);
+                }
+                else
+                {
+                    Log.Information("[VIDEO PLAYER] MediaPlayer is null, cannot restart video");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[VIDEO PLAYER] Failed to restart video: {Message}", ex.Message);
+            }
+        }
+
         public void EndShow()
         {
             try


### PR DESCRIPTION
## Summary
- stop logging slider updates driven by playback; only log when user is actively seeking
- expose `IsSeeking` and add restart helper to bring video back after stopping

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab57c6fee08323a17fd77363ab843c