### PR TITLE
Remove verbose VLC position logging

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -312,7 +312,6 @@ namespace BNKaraoke.DJ.ViewModels
                                 CurrentVideoPosition = TimeSpan.FromSeconds(newPosition).ToString(@"m\:ss");
                                 OnPropertyChanged(nameof(SongPosition));
                                 OnPropertyChanged(nameof(CurrentVideoPosition));
-                                Log.Verbose("[DJSCREEN] VLC PositionChanged: {Position}", newPosition);
                             }
                         }
                         catch (Exception ex)


### PR DESCRIPTION
## Summary
- reduce VLC position change logging to avoid excessive log noise

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab59f5bdb0832393eaff54abd7a82c