### PR TITLE
Fix null username warnings in queue management

### DIFF
--- a/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
+++ b/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
@@ -427,8 +427,14 @@ namespace BNKaraoke.Api.Controllers
                     .ToListAsync();
                 _logger.LogInformation("ReorderQueue: Final EventQueues query took {ElapsedMilliseconds} ms", swFinalQueue.ElapsedMilliseconds);
 
-                var requestorUserNames = queueEntries.Select(eq => eq.RequestorUserName).Distinct().ToList();
-                var allUsers = await _context.Users.Where(u => requestorUserNames.Contains(u.UserName)).ToDictionaryAsync(u => u.UserName!);
+                var requestorUserNames = queueEntries
+                    .Select(eq => eq.RequestorUserName)
+                    .Where(name => !string.IsNullOrEmpty(name))
+                    .Distinct()
+                    .ToList();
+                var allUsers = await _context.Users
+                    .Where(u => !string.IsNullOrEmpty(u.UserName) && requestorUserNames.Contains(u.UserName))
+                    .ToDictionaryAsync(u => u.UserName!);
 
                 var queueDtos = queueEntries.Select(eq =>
                 {
@@ -576,8 +582,14 @@ namespace BNKaraoke.Api.Controllers
                     .ToListAsync();
                 _logger.LogInformation("ReorderPersonalQueue: Final EventQueues query took {ElapsedMilliseconds} ms", swFinalQueue.ElapsedMilliseconds);
 
-                var requestorUserNames = updatedQueue.Select(eq => eq.RequestorUserName).Distinct().ToList();
-                var allUsers = await _context.Users.Where(u => requestorUserNames.Contains(u.UserName)).ToDictionaryAsync(u => u.UserName!);
+                var requestorUserNames = updatedQueue
+                    .Select(eq => eq.RequestorUserName)
+                    .Where(name => !string.IsNullOrEmpty(name))
+                    .Distinct()
+                    .ToList();
+                var allUsers = await _context.Users
+                    .Where(u => !string.IsNullOrEmpty(u.UserName) && requestorUserNames.Contains(u.UserName))
+                    .ToDictionaryAsync(u => u.UserName!);
 
                 var queueDtos = updatedQueue.Select(eq =>
                 {


### PR DESCRIPTION
## Summary
- avoid passing null usernames to Contains when building user dictionaries
- guard against empty usernames in queue processing

## Testing
- `dotnet build BNKaraoke.Api/BNKaraoke.Api.csproj -warnaserror` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6f0bc53c8323b4852bb70fa45e47