### PR TITLE
Handle expired tokens gracefully and extend JWT lifetime

### DIFF
--- a/BNKaraoke.Api/Controllers/AuthController.cs
+++ b/BNKaraoke.Api/Controllers/AuthController.cs
@@ -691,7 +691,8 @@ namespace BNKaraoke.Api.Controllers
                 issuer: issuer,
                 audience: audience,
                 claims: claims,
-                expires: DateTime.UtcNow.AddHours(2),
+                // Extend token lifetime to 12 hours to minimize re-authentication during events
+                expires: DateTime.UtcNow.AddHours(12),
                 signingCredentials: creds);
 
             return new JwtSecurityTokenHandler().WriteToken(token);

--- a/bnkaraoke.web/src/context/EventContext.tsx
+++ b/bnkaraoke.web/src/context/EventContext.tsx
@@ -22,7 +22,7 @@ interface EventContextType {
   fetchError: string | null;
   setFetchError: React.Dispatch<React.SetStateAction<string | null>>;
   isLoggedIn: boolean;
-  logout: () => void;
+  logout: (message?: string) => void;
   selectionRequired: boolean; // New flag for selection UI
   setSelectionRequired: React.Dispatch<React.SetStateAction<boolean>>;
   noEvents: boolean; // New flag for no events case
@@ -57,36 +57,32 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
     }
     if (!token || !userName) {
       console.error("[EVENT_CONTEXT] No token or userName found", { token, userName });
-      toast.error("Authentication token or username missing. Please log in again.");
-      navigate("/login");
+      logout("Authentication token or username missing. Please log in again.");
       return null;
     }
     try {
       if (token!.split('.').length !== 3) {
         console.error("[EVENT_CONTEXT] Malformed token: does not contain three parts");
-        toast.error("Invalid token format. Please log in again.");
-        navigate("/login");
+        logout("Invalid token format. Please log in again.");
         return null;
       }
       const payload = JSON.parse(atob(token!.split('.')[1]));
       const exp = payload.exp * 1000;
       if (exp < Date.now()) {
         console.error("[EVENT_CONTEXT] Token expired:", { exp: new Date(exp).toISOString(), now: new Date().toISOString() });
-        toast.error("Session expired. Please log in again.");
-        navigate("/login");
+        logout("Session expired. Please log in again.");
         return null;
       }
       console.log("[EVENT_CONTEXT] Token validated:", { userName, exp: new Date(exp).toISOString() });
       return token;
     } catch (err) {
       console.error("[EVENT_CONTEXT] Token validation error:", err);
-      toast.error("Invalid token. Please log in again.");
-      navigate("/login");
+      logout("Invalid token. Please log in again.");
       return null;
     }
   };
 
-  const logout = () => {
+  const logout = (message?: string) => {
     console.log("[LOGOUT] Logging out");
     localStorage.clear();
     setIsLoggedIn(false);
@@ -100,7 +96,11 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
     setSelectionRequired(false);
     setNoEvents(false);
     navigate("/login");
-    toast.success("Logged out successfully!");
+    if (message) {
+      toast.error(message);
+    } else {
+      toast.success("Logged out successfully!");
+    }
   };
 
   const checkAttendanceStatus = async (event: Event) => {

--- a/bnkaraoke.web/src/pages/Dashboard.tsx
+++ b/bnkaraoke.web/src/pages/Dashboard.tsx
@@ -14,6 +14,7 @@ import QueuePanel from '../components/QueuePanel';
 import GlobalQueuePanel from '../components/GlobalQueuePanel';
 import FavoritesSection from '../components/FavoritesSection';
 import Modals from '../components/Modals';
+import { logoutAndRedirect } from '../utils/auth';
 
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
@@ -51,7 +52,7 @@ const Dashboard: React.FC = () => {
     if (!token || !userName) {
       console.error("[VALIDATE_TOKEN] No token or userName found", { token: !!token, userName: !!userName });
       toast.error("Authentication token or username missing. Please log in again.");
-      navigate("/login");
+      logoutAndRedirect(navigate);
       return null;
     }
     try {
@@ -59,12 +60,7 @@ const Dashboard: React.FC = () => {
       if (token.split('.').length !== 3) {
         console.error("[VALIDATE_TOKEN] Malformed token: does not contain three parts", { parts: token.split('.') });
         toast.error("Invalid token format. Please log in again.");
-        localStorage.removeItem("token");
-        localStorage.removeItem("userName");
-        localStorage.removeItem("firstName");
-        localStorage.removeItem("lastName");
-        localStorage.removeItem("roles");
-        navigate("/login");
+        logoutAndRedirect(navigate);
         return null;
       }
       const payload = JSON.parse(atob(token.split('.')[1]));
@@ -73,12 +69,7 @@ const Dashboard: React.FC = () => {
       if (exp < Date.now()) {
         console.error("[VALIDATE_TOKEN] Token expired:", { exp: new Date(exp).toISOString(), now: new Date().toISOString() });
         toast.error("Session expired. Please log in again.");
-        localStorage.removeItem("token");
-        localStorage.removeItem("userName");
-        localStorage.removeItem("firstName");
-        localStorage.removeItem("lastName");
-        localStorage.removeItem("roles");
-        navigate("/login");
+        logoutAndRedirect(navigate);
         return null;
       }
       console.log("[VALIDATE_TOKEN] Token validated:", { userName, exp: new Date(exp).toISOString() });
@@ -86,12 +77,7 @@ const Dashboard: React.FC = () => {
     } catch (err) {
       console.error("[VALIDATE_TOKEN] Error:", err, { token });
       toast.error("Invalid token. Please log in again.");
-      localStorage.removeItem("token");
-      localStorage.removeItem("userName");
-      localStorage.removeItem("firstName");
-      localStorage.removeItem("lastName");
-      localStorage.removeItem("roles");
-      navigate("/login");
+      logoutAndRedirect(navigate);
       return null;
     }
   }, [navigate]);

--- a/bnkaraoke.web/src/utils/auth.js
+++ b/bnkaraoke.web/src/utils/auth.js
@@ -2,3 +2,19 @@ export const getUserRole = () => {
     const user = JSON.parse(localStorage.getItem('user'));
     return user?.role || 'guest'; // Default to guest if no role is found
 };
+
+// Clear all authentication-related data from localStorage
+export const clearAuthData = () => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('userName');
+    localStorage.removeItem('firstName');
+    localStorage.removeItem('lastName');
+    localStorage.removeItem('roles');
+    localStorage.removeItem('mustChangePassword');
+};
+
+// Convenience helper to wipe auth data and navigate to login
+export const logoutAndRedirect = (navigate) => {
+    clearAuthData();
+    navigate('/login', { replace: true });
+};


### PR DESCRIPTION
## Summary
- Extend JWT token expiry to 12 hours to reduce re-login frequency
- Add utilities to clear auth data and redirect to login
- Automatically redirect to login when tokens are missing or expired across the app

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab943948f883238af020369975ab0d