### PR TITLE
Include missing TransactionScope namespace

### DIFF
--- a/BNKaraoke.Api/Controllers/EventController.Attendance.cs
+++ b/BNKaraoke.Api/Controllers/EventController.Attendance.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore.Storage;
+using System.Transactions;
 
 namespace BNKaraoke.Api.Controllers
 {


### PR DESCRIPTION
## Summary
- add System.Transactions namespace to EventController attendance actions

## Testing
- `dotnet build BNKaraoke.Api` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9f5d16ec832397d0812905957a34