### PR TITLE
Reduce mobile queue item spacing

### DIFF
--- a/bnkaraoke.web/src/components/QueuePanel.css
+++ b/bnkaraoke.web/src/components/QueuePanel.css
@@ -78,7 +78,7 @@
     max-height: 300px;
   }
   .queue-item {
-    padding: 6px;
+    padding: 3px 6px;
     font-size: 14px;
   }
   .queue-count {


### PR DESCRIPTION
## Summary
- tighten vertical spacing for personal queue entries on small screens

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ac7570cc0c832397a9c65bd6e23110