### PR TITLE
Tighten mobile queue spacing and brighten drag handle

### DIFF
--- a/bnkaraoke.web/src/components/QueuePanel.css
+++ b/bnkaraoke.web/src/components/QueuePanel.css
@@ -78,7 +78,7 @@
     max-height: 300px;
   }
   .queue-item {
-    padding: 3px 6px;
+    padding: 1px 6px;
     font-size: 14px;
   }
   .queue-count {

--- a/bnkaraoke.web/src/components/SortableItem.css
+++ b/bnkaraoke.web/src/components/SortableItem.css
@@ -10,7 +10,7 @@
   display: inline-flex;
   margin-right: 8px;
   font-size: 16px;
-  color: #666;
+  color: #22d3ee;
   cursor: grab;
 }
 
@@ -20,7 +20,7 @@
 
 /* Hover effect for desktop */
 .mobile-sortable-item:hover .drag-handle {
-  color: #22d3ee;
+  color: #40e0ff;
 }
 
 /* Disabled state */
@@ -45,6 +45,6 @@
     margin-right: 4px;
   }
   .mobile-sortable-item {
-    margin-bottom: 4px; /* Adjusted spacing */
+    margin-bottom: 2px; /* Reduced spacing */
   }
 }


### PR DESCRIPTION
## Summary
- Reduce mobile queue item padding for a more compact personal queue
- Brighten drag handle icon and lower mobile spacing between sortable items

## Testing
- `CI=true npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ac785ee3048323ad08fb80272778ea