### PR TITLE
fix: include search query in dashboard callbacks

### DIFF
--- a/bnkaraoke.web/src/pages/Dashboard.tsx
+++ b/bnkaraoke.web/src/pages/Dashboard.tsx
@@ -183,7 +183,7 @@ const Dashboard: React.FC = () => {
     } finally {
       setIsSearching(false);
     }
-    }, [serverAvailable, validateToken, navigate]);
+    }, [serverAvailable, validateToken, navigate, searchQuery]);
 
   const fetchSpotifySongs = useCallback(async () => {
     if (!serverAvailable) {
@@ -231,7 +231,7 @@ const Dashboard: React.FC = () => {
       }
       setShowSpotifyModal(true);
     }
-    }, [serverAvailable, validateToken, navigate]);
+    }, [serverAvailable, validateToken, navigate, searchQuery]);
 
   const handleSpotifySongSelect = useCallback((song: SpotifySong) => {
     console.log("[SPOTIFY_SELECT] Selected song:", song);


### PR DESCRIPTION
## Summary
- include `searchQuery` in dependency arrays for search callbacks to satisfy React hook rules

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac94b13f908323a4b0abcc4c9ad1cd