### PR TITLE
Improve queue management UX and search queue actions

### DIFF
--- a/bnkaraoke.web/src/components/GlobalQueuePanel.tsx
+++ b/bnkaraoke.web/src/components/GlobalQueuePanel.tsx
@@ -12,6 +12,7 @@ interface GlobalQueuePanelProps {
   songDetailsMap: { [songId: number]: Song };
   handleGlobalQueueItemClick: (song: Song) => void;
   enableDragAndDrop: boolean;
+  isLoading: boolean;
 }
 
 const GlobalQueuePanel: React.FC<GlobalQueuePanelProps> = ({
@@ -23,6 +24,7 @@ const GlobalQueuePanel: React.FC<GlobalQueuePanelProps> = ({
   songDetailsMap,
   handleGlobalQueueItemClick,
   enableDragAndDrop: _enableDragAndDrop,
+  isLoading,
 }) => {
   const userName = localStorage.getItem("userName") || "";
   const filteredGlobalQueue = globalQueue.filter(item => item.sungAt === null && item.wasSkipped === false);
@@ -56,8 +58,10 @@ const GlobalQueuePanel: React.FC<GlobalQueuePanelProps> = ({
           <h3 className="queue-count">
             {currentEvent.description} (In Queue: {filteredGlobalQueue.length} -- Songs Sung: {songsSung})
           </h3>
-          {filteredGlobalQueue.length === 0 ? (
-            <p className="info-text">No songs in the Karaoke DJ Queue.</p>
+          {isLoading ? (
+            <p className="info-text">Loading Songs...</p>
+          ) : filteredGlobalQueue.length === 0 ? (
+            <p className="info-text">No Songs in Queue</p>
           ) : (
             <div className="event-queue">
               {filteredGlobalQueue.map((queueItem: EventQueueItem) => {

--- a/bnkaraoke.web/src/components/Modals.tsx
+++ b/bnkaraoke.web/src/components/Modals.tsx
@@ -306,12 +306,27 @@ const Modals: React.FC<ModalsProps> = ({
             setSelectedSong(null);
             setSearchError(null);
           }}
-          onToggleFavorite={selectedSong.status?.toLowerCase() === 'active' ? toggleFavorite : undefined}
-          onAddToQueue={selectedSong.status?.toLowerCase() === 'active' ? addToEventQueue : undefined}
-          onDeleteFromQueue={selectedSong.status?.toLowerCase() === 'active' ? handleDeleteSong : undefined}
+          onToggleFavorite={
+            selectedSong.status && ['active', 'available'].includes(selectedSong.status.toLowerCase())
+              ? toggleFavorite
+              : undefined
+          }
+          onAddToQueue={
+            selectedSong.status && ['active', 'available'].includes(selectedSong.status.toLowerCase())
+              ? addToEventQueue
+              : undefined
+          }
+          onDeleteFromQueue={
+            selectedSong.status && ['active', 'available'].includes(selectedSong.status.toLowerCase())
+              ? handleDeleteSong
+              : undefined
+          }
           eventId={currentEvent?.eventId}
           queueId={selectedQueueId}
-          readOnly={isSingerOnly || selectedSong.status?.toLowerCase() !== 'active'}
+          readOnly={
+            isSingerOnly ||
+            !(selectedSong.status && ['active', 'available'].includes(selectedSong.status.toLowerCase()))
+          }
           checkedIn={checkedIn}
           isCurrentEventLive={isCurrentEventLive}
         />

--- a/bnkaraoke.web/src/components/QueuePanel.tsx
+++ b/bnkaraoke.web/src/components/QueuePanel.tsx
@@ -17,6 +17,7 @@ interface QueuePanelProps {
   handleQueueItemClick: (song: Song, queueId: number, eventId: number) => void;
   handleDragEnd: (event: any) => void;
   enableDragAndDrop: boolean;
+  isLoading: boolean;
 }
 
 const QueuePanel: React.FC<QueuePanelProps> = ({
@@ -30,6 +31,7 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
   handleQueueItemClick,
   handleDragEnd,
   enableDragAndDrop,
+  isLoading,
 }) => {
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -56,8 +58,10 @@ const QueuePanel: React.FC<QueuePanelProps> = ({
         </p>
       )}
       {reorderError && showReorderErrorModal && <p className="error-text">{reorderError}</p>}
-      {queueItems.length === 0 && currentEvent && checkedIn ? (
-        <p className="info-text">Your queue is empty. Add a song to get started!</p>
+      {isLoading ? (
+        <p className="info-text">Loading Songs...</p>
+      ) : queueItems.length === 0 && currentEvent && checkedIn ? (
+        <p className="info-text">No Songs in Queue</p>
       ) : (
         checkedIn && currentEvent && (
           <DndContext

--- a/bnkaraoke.web/src/components/SongDetailsModal.tsx
+++ b/bnkaraoke.web/src/components/SongDetailsModal.tsx
@@ -345,20 +345,24 @@ const SongDetailsModal: React.FC<SongDetailsModalProps> = ({
                   {isDeleting ? "Deleting..." : "Remove from Queue"}
                 </button>
               ) : (
-                checkedIn && isCurrentEventLive && onAddToQueue && currentEvent && (
+                checkedIn && isCurrentEventLive && onAddToQueue && (currentEvent || eventId) && (
                   <button
                     onClick={() => {
-                      console.log("Add to Queue button clicked with currentEvent:", currentEvent);
-                      handleAddToQueue(currentEvent.eventId);
+                      const targetEventId = eventId ?? currentEvent?.eventId;
+                      console.log("Add to Queue button clicked with event:", targetEventId);
+                      if (targetEventId) handleAddToQueue(targetEventId);
                     }}
                     onTouchEnd={() => {
-                      console.log("Add to Queue button touched with currentEvent:", currentEvent);
-                      handleAddToQueue(currentEvent.eventId);
+                      const targetEventId = eventId ?? currentEvent?.eventId;
+                      console.log("Add to Queue button touched with event:", targetEventId);
+                      if (targetEventId) handleAddToQueue(targetEventId);
                     }}
                     className="action-button"
                     disabled={isAddingToQueue || isInQueue}
                   >
-                    {isAddingToQueue ? "Adding..." : `Add to Queue: ${currentEvent.eventCode}`}
+                    {isAddingToQueue
+                      ? "Adding..."
+                      : `Add to Queue${currentEvent?.eventCode ? `: ${currentEvent.eventCode}` : ""}`}
                   </button>
                 )
               )}

--- a/bnkaraoke.web/src/pages/Dashboard.tsx
+++ b/bnkaraoke.web/src/pages/Dashboard.tsx
@@ -77,7 +77,7 @@ const Dashboard: React.FC = () => {
     }
   }, [logout]);
 
-  const { signalRError, serverAvailable: signalRServerAvailable } = useSignalR({
+  const { signalRError, serverAvailable: signalRServerAvailable, queuesLoading } = useSignalR({
     currentEvent,
     isCurrentEventLive,
     checkedIn,
@@ -419,7 +419,8 @@ const Dashboard: React.FC = () => {
   }, [favorites, serverAvailable, validateToken, navigate]);
 
   const addToEventQueue = useCallback(async (song: Song, eventId: number): Promise<void> => {
-    if (song.status?.toLowerCase() !== 'active') {
+    const status = song.status?.toLowerCase();
+    if (!status || !['active', 'available'].includes(status)) {
       toast.error('Only Available songs can be added to the queue.');
       return;
     }
@@ -723,8 +724,9 @@ const Dashboard: React.FC = () => {
       handleQueueItemClick={handleQueueItemClick}
       handleDragEnd={handleDragEnd}
       enableDragAndDrop={serverAvailable && checkedIn}
+      isLoading={queuesLoading}
     />
-  ), [currentEvent, checkedIn, isCurrentEventLive, myQueues, songDetailsMap, reorderError, showReorderErrorModal, handleQueueItemClick, handleDragEnd, serverAvailable]);
+  ), [currentEvent, checkedIn, isCurrentEventLive, myQueues, songDetailsMap, reorderError, showReorderErrorModal, handleQueueItemClick, handleDragEnd, serverAvailable, queuesLoading]);
 
   const MemoizedGlobalQueuePanel = useMemo(() => (
     <GlobalQueuePanel
@@ -736,8 +738,9 @@ const Dashboard: React.FC = () => {
       songDetailsMap={songDetailsMap}
       handleGlobalQueueItemClick={handleGlobalQueueItemClick}
       enableDragAndDrop={false}
+      isLoading={queuesLoading}
     />
-  ), [currentEvent, checkedIn, isCurrentEventLive, globalQueue, myQueues, songDetailsMap, handleGlobalQueueItemClick]);
+  ), [currentEvent, checkedIn, isCurrentEventLive, globalQueue, myQueues, songDetailsMap, handleGlobalQueueItemClick, queuesLoading]);
 
   const [isMobile, setIsMobile] = useState(window.matchMedia("(max-width: 767px)").matches);
 


### PR DESCRIPTION
## Summary
- allow songs with status `available` to be added from search results
- display "Loading Songs" and "No Songs in Queue" messaging while SignalR queues load
- ensure song details fall back to provided event when adding to queue

## Testing
- `npm test -- --watchAll=false` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9a80cdac8323bff4c5587e71fccb