### PR TITLE
Hide event actions after joining event

### DIFF
--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -50,7 +50,7 @@ const Header: React.FC = memo(() => {
         eventActionsOffsetTop: eventActions?.offsetTop,
         eventActionsHeight: eventActions?.offsetHeight,
         eventActionsVisible: eventActions?.offsetParent !== null,
-        renderCondition: !currentEvent || location.pathname === "/dashboard",
+        renderCondition: !checkedIn && (!currentEvent || location.pathname === "/dashboard"),
       });
     };
     handleResize();
@@ -818,7 +818,7 @@ const Header: React.FC = memo(() => {
             )}
           </div>
         )}
-        {(!currentEvent || location.pathname === "/dashboard") && (
+        {(!checkedIn && (!currentEvent || location.pathname === "/dashboard")) && (
           <div className="event-actions" ref={eventActionsRef}>
             {isLoadingEvents ? (
               <span>Loading events...</span>


### PR DESCRIPTION
## Summary
- Hide Pre-Select and Join Event buttons when user already joined a live event
- Update debug logging to reflect new render condition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad084f847483239f6edbb6f7b5b3ca