### PR TITLE
feat: expose API maintenance page in admin menu

### DIFF
--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -65,6 +65,7 @@ const Header: React.FC = memo(() => {
     "/song-manager",
     "/user-management",
     "/event-management",
+    "/api-maintenance",
   ], []);
 
   const validateToken = useCallback(() => {
@@ -549,6 +550,15 @@ const Header: React.FC = memo(() => {
                       Manage Events
                     </li>
                   )}
+                  {roles.includes("Application Manager") && (
+                    <li
+                      className="dropdown-item"
+                      onClick={() => handleNavigation("/api-maintenance")}
+                      onTouchStart={() => handleNavigation("/api-maintenance")}
+                    >
+                      API Maintenance
+                    </li>
+                  )}
                 </ul>
               )}
             </div>
@@ -776,6 +786,15 @@ const Header: React.FC = memo(() => {
                     onTouchStart={() => handleNavigation("/event-management")}
                   >
                     Manage Events
+                  </li>
+                )}
+                {roles.includes("Application Manager") && (
+                  <li
+                    className="dropdown-item"
+                    onClick={() => handleNavigation("/api-maintenance")}
+                    onTouchStart={() => handleNavigation("/api-maintenance")}
+                  >
+                    API Maintenance
                   </li>
                 )}
               </ul>

--- a/bnkaraoke.web/src/context/EventContext.tsx
+++ b/bnkaraoke.web/src/context/EventContext.tsx
@@ -140,11 +140,11 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
   const checkAttendanceStatus = useCallback(async (event: Event) => {
     const token = validateToken();
     if (!token) return { isCheckedIn: false, isOnBreak: false };
-    const isRestrictedPage = location.pathname.startsWith('/admin') || [
-      '/song-manager', '/user-management', '/event-management',
-      '/explore-songs', '/profile', '/request-song', '/spotify-search',
-      '/karaoke-channels', '/pending-requests', '/add-requests'
-    ].includes(location.pathname);
+      const isRestrictedPage = location.pathname.startsWith('/admin') || [
+        '/song-manager', '/user-management', '/event-management',
+        '/explore-songs', '/profile', '/request-song', '/spotify-search',
+        '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
+      ].includes(location.pathname);
     console.log("[EVENT_CONTEXT] Checking attendance status:", { eventId: event.eventId, isRestrictedPage });
     try {
       console.log(`[EVENT_CONTEXT] Fetching attendance status for event ${event.eventId}`);
@@ -230,7 +230,7 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
       const isRestrictedPage = location.pathname.startsWith('/admin') || [
         '/song-manager', '/user-management', '/event-management',
         '/explore-songs', '/profile', '/request-song', '/spotify-search',
-        '/karaoke-channels', '/pending-requests', '/add-requests'
+        '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
       ].includes(location.pathname);
       if (isRestrictedPage) {
         console.log("[EVENT_CONTEXT] Skipping auto-check-in on restricted page:", location.pathname);
@@ -320,7 +320,7 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
       const isRestrictedPage = location.pathname.startsWith('/admin') || [
         '/song-manager', '/user-management', '/event-management',
         '/explore-songs', '/profile', '/request-song', '/spotify-search',
-        '/karaoke-channels', '/pending-requests', '/add-requests'
+        '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
       ].includes(location.pathname);
       if (isRestrictedPage) {
         console.log("[EVENT_CONTEXT] Skipping fetchAttendanceStatus on restricted page:", location.pathname);


### PR DESCRIPTION
## Summary
- add API maintenance to admin dropdowns
- mark API maintenance as restricted route

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68adc9210b648323920524175ff57534