### PR TITLE
fix: support yt-dlp on Windows

### DIFF
--- a/BNKaraoke.Api/Services/SongCacheService.cs
+++ b/BNKaraoke.Api/Services/SongCacheService.cs
@@ -50,9 +50,10 @@ namespace BNKaraoke.Api.Services
                     return true;
                 }
 
+                var ytDlpExecutable = OperatingSystem.IsWindows() ? "yt-dlp.exe" : "yt-dlp";
                 var psi = new ProcessStartInfo
                 {
-                    FileName = "yt-dlp",
+                    FileName = ytDlpExecutable,
                     Arguments = $"--output \"{filePath}\" -f mp4 \"{youTubeUrl}\"",
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,

--- a/BNKaraoke.DJ/Services/VideoCacheService.cs
+++ b/BNKaraoke.DJ/Services/VideoCacheService.cs
@@ -51,8 +51,10 @@ public class VideoCacheService
 
             Directory.CreateDirectory(_settingsService.Settings.VideoCachePath);
 
-            string ytDlpPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tools", "yt-dlp.exe");
-            string ffmpegPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tools", "ffmpeg.exe");
+            string ytDlpExecutable = OperatingSystem.IsWindows() ? "yt-dlp.exe" : "yt-dlp";
+            string ffmpegExecutable = OperatingSystem.IsWindows() ? "ffmpeg.exe" : "ffmpeg";
+            string ytDlpPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tools", ytDlpExecutable);
+            string ffmpegPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Tools", ffmpegExecutable);
 
             // Use higher resolution format (up to 1080p)
             string args = $"--output \"{cachePath}\" --format bestvideo[height<=1080][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4] --merge-output-format mp4 --ffmpeg-location \"{ffmpegPath}\" \"{youTubeUrl}\"";


### PR DESCRIPTION
## Summary
- detect yt-dlp executable per OS when caching songs
- support cross-platform yt-dlp/ffmpeg paths in DJ video caching service

## Testing
- `dotnet build BNKaraoke.Api/BNKaraoke.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adcc7757f083239b6e74fd2534a0c1