### PR TITLE
Add API setting for yt-dlp executable path

### DIFF
--- a/BNKaraoke.Api/Services/SongCacheService.cs
+++ b/BNKaraoke.Api/Services/SongCacheService.cs
@@ -50,7 +50,13 @@ namespace BNKaraoke.Api.Services
                     return true;
                 }
 
-                var ytDlpExecutable = OperatingSystem.IsWindows() ? "yt-dlp.exe" : "yt-dlp";
+                var ytDlpPath = await context.ApiSettings
+                    .Where(s => s.SettingKey == "YtDlpPath")
+                    .Select(s => s.SettingValue)
+                    .FirstOrDefaultAsync(cancellationToken);
+                var ytDlpExecutable = !string.IsNullOrWhiteSpace(ytDlpPath)
+                    ? ytDlpPath
+                    : (OperatingSystem.IsWindows() ? "yt-dlp.exe" : "yt-dlp");
                 var psi = new ProcessStartInfo
                 {
                     FileName = ytDlpExecutable,

--- a/Scripts/ApiMaintenance.sql
+++ b/Scripts/ApiMaintenance.sql
@@ -4,3 +4,5 @@ ALTER TABLE public."Songs" ADD COLUMN IF NOT EXISTS "Cached" boolean NOT NULL DE
 -- Insert settings for cache path and download delay
 INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('CacheStoragePath', '/var/bnkaraoke/cache');
 INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('CacheDownloadDelaySeconds', '5');
+-- Full path to the yt-dlp executable used for caching
+INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('YtDlpPath', '/usr/local/bin/yt-dlp');


### PR DESCRIPTION
## Summary
- allow configuring yt-dlp executable path via `ApiSettings`
- seed database with `YtDlpPath` example entry

## Testing
- `dotnet build BNKaraoke.Api/BNKaraoke.Api.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68add152682c8323a8a8bc2478398413