### PR TITLE
Cache YouTube songs on approval

### DIFF
--- a/BNKaraoke.Api/Controllers/SongController.cs
+++ b/BNKaraoke.Api/Controllers/SongController.cs
@@ -794,6 +794,21 @@ namespace BNKaraoke.Api.Controllers
                     _logger.LogWarning("ApproveSong: ApprovedBy is null. Claims: {Claims}", string.Join(", ", User.Claims.Select(c => $"{c.Type}: {c.Value}")));
                 }
                 await _context.SaveChangesAsync();
+
+                if (!string.IsNullOrWhiteSpace(song.YouTubeUrl))
+                {
+                    var cached = await _songCacheService.CacheSongAsync(song.Id, song.YouTubeUrl);
+                    if (cached)
+                    {
+                        song.Cached = true;
+                        await _context.SaveChangesAsync();
+                    }
+                    else
+                    {
+                        _logger.LogWarning("ApproveSong: Failed to cache song {SongId}", song.Id);
+                    }
+                }
+
                 _logger.LogInformation("ApproveSong: Song '{Title}' approved by {ApprovedBy} in {TotalElapsedMilliseconds} ms", song.Title, song.ApprovedBy, sw.ElapsedMilliseconds);
                 return Ok(new { message = "Party hit approved!" });
             }


### PR DESCRIPTION
## Summary
- cache songs via SongCacheService when approving a song so the file is stored and marked as cached

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68adddd458748323823bb7ba5a897909