### PR TITLE
Add DJ cache manifest and streaming endpoints

### DIFF
--- a/BNKaraoke.Api/Controllers/CacheController.cs
+++ b/BNKaraoke.Api/Controllers/CacheController.cs
@@ -1,0 +1,67 @@
+using BNKaraoke.Api.Data;
+using BNKaraoke.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BNKaraoke.Api.Controllers
+{
+    [ApiController]
+    [Route("api/cache")]
+    [Authorize(Policy = "KaraokeDJ")]
+    public class CacheController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ISongCacheService _songCacheService;
+
+        public CacheController(ApplicationDbContext context, ISongCacheService songCacheService)
+        {
+            _context = context;
+            _songCacheService = songCacheService;
+        }
+
+        [HttpGet("manifest")]
+        public async Task<IActionResult> GetManifest()
+        {
+            var songIds = await _context.Songs
+                .AsNoTracking()
+                .Where(s => s.Cached)
+                .Select(s => s.Id)
+                .ToListAsync();
+
+            var manifest = new List<object>();
+
+            foreach (var id in songIds)
+            {
+                var info = await _songCacheService.GetCachedSongFileInfoAsync(id);
+                if (info != null)
+                {
+                    manifest.Add(new
+                    {
+                        songId = id,
+                        fileSize = info.Length,
+                        lastModified = info.LastWriteTimeUtc
+                    });
+                }
+            }
+
+            return Ok(manifest);
+        }
+
+        [HttpGet("{songId}")]
+        public async Task<IActionResult> GetCachedSong(int songId)
+        {
+            var stream = await _songCacheService.OpenCachedSongStreamAsync(songId);
+            if (stream == null)
+            {
+                return NotFound();
+            }
+
+            return File(stream, "video/mp4", enableRangeProcessing: true);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DJ-only cache controller serving manifest of cached songs and streaming MP4 files
- extend song cache service with helpers for file metadata and stream access

## Testing
- `dotnet build BNKaraoke.Api/BNKaraoke.Api.csproj` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68af623e968c83239132c076e23c95c3