### PR TITLE
Expose server cache status in queue DTOs

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -295,7 +295,8 @@ namespace BNKaraoke.Api.Controllers
                     IsUpNext = false,
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
-                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false
+                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
+                    IsServerCached = queueEntry.Song?.Cached ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDto, "Playing");
                 _logger.LogInformation("[DJController] Started play for QueueId: {QueueId} for EventId: {EventId}", queueId, eventId);
@@ -369,7 +370,8 @@ namespace BNKaraoke.Api.Controllers
                     IsUpNext = false,
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
-                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false
+                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
+                    IsServerCached = queueEntry.Song?.Cached ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDto, "Skipped");
                 _logger.LogInformation("[DJController] Skipped song with QueueId: {QueueId} for EventId: {EventId}", queueId, eventId);
@@ -449,7 +451,8 @@ namespace BNKaraoke.Api.Controllers
                     IsUpNext = false,
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
-                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false
+                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
+                    IsServerCached = queueEntry.Song?.Cached ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{queueEntry.EventId}").SendAsync("QueueUpdated", queueDto, "Playing");
                 _logger.LogInformation("[DJController] Set now playing for QueueId: {QueueId}, EventId: {EventId}", request.QueueId, queueEntry.EventId);
@@ -557,7 +560,8 @@ namespace BNKaraoke.Api.Controllers
                             IsUpNext = false,
                             IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                             IsSingerJoined = singerStatus?.IsJoined ?? false,
-                            IsSingerOnBreak = singerStatus?.IsOnBreak ?? false
+                            IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
+                            IsServerCached = entry.Song?.Cached ?? false
                         };
                         await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDto, "OnHold");
                     }
@@ -613,7 +617,8 @@ namespace BNKaraoke.Api.Controllers
                     IsUpNext = false,
                     IsSingerLoggedIn = nextSingerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = nextSingerStatus?.IsJoined ?? false,
-                    IsSingerOnBreak = nextSingerStatus?.IsOnBreak ?? false
+                    IsSingerOnBreak = nextSingerStatus?.IsOnBreak ?? false,
+                    IsServerCached = nextEntry.Song?.Cached ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", nextQueueDto, "Playing");
                 _logger.LogInformation("[DJController] Selected next song for autoplay: QueueId: {QueueId}, EventId: {EventId}", nextEntry.QueueId, eventId);
@@ -982,7 +987,8 @@ namespace BNKaraoke.Api.Controllers
                     IsUpNext = false,
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
-                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false
+                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
+                    IsServerCached = queueEntry.Song?.Cached ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{request.EventId}").SendAsync("QueueUpdated", queueDto, "Sung");
                 _logger.LogInformation("[DJController] Completed song with QueueId: {QueueId} for EventId: {EventId}", request.QueueId, request.EventId);
@@ -1058,7 +1064,8 @@ namespace BNKaraoke.Api.Controllers
                     IsUpNext = false,
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
-                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false
+                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
+                    IsServerCached = queueEntry.Song?.Cached ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{request.EventId}").SendAsync("QueueUpdated", queueDto, request.IsOnBreak ? "OnHold" : "Eligible");
                 _logger.LogInformation("[DJController] Toggled break for QueueId: {QueueId} to IsOnBreak: {IsOnBreak} for EventId: {EventId}", request.QueueId, request.IsOnBreak, request.EventId);
@@ -1200,7 +1207,8 @@ namespace BNKaraoke.Api.Controllers
                             IsUpNext = false,
                             IsSingerLoggedIn = request.IsLoggedIn,
                             IsSingerJoined = request.IsJoined,
-                            IsSingerOnBreak = request.IsOnBreak
+                            IsSingerOnBreak = request.IsOnBreak,
+                            IsServerCached = entry.Song?.Cached ?? false
                         };
                         await _hubContext.Clients.Group($"Event_{request.EventId}").SendAsync("QueueUpdated", queueDto, holdReason != "None" ? "Held" : "Eligible");
                     }
@@ -1343,7 +1351,8 @@ namespace BNKaraoke.Api.Controllers
                     IsUpNext = false,
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
-                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false
+                    IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
+                    IsServerCached = eq.Song?.Cached ?? false
                 };
                 queueDtos.Add(queueDto);
             }

--- a/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
+++ b/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
@@ -162,7 +162,8 @@ namespace BNKaraoke.Api.Controllers
                     WasSkipped = newQueueEntry.WasSkipped,
                     IsCurrentlyPlaying = newQueueEntry.IsCurrentlyPlaying,
                     SungAt = newQueueEntry.SungAt,
-                    IsOnBreak = newQueueEntry.IsOnBreak
+                    IsOnBreak = newQueueEntry.IsOnBreak,
+                    IsServerCached = song.Cached
                 };
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueEntryDto, "Added");
@@ -308,7 +309,8 @@ namespace BNKaraoke.Api.Controllers
                         WasSkipped = eq.WasSkipped,
                         IsCurrentlyPlaying = eq.IsCurrentlyPlaying,
                         SungAt = eq.SungAt,
-                        IsOnBreak = eq.IsOnBreak
+                        IsOnBreak = eq.IsOnBreak,
+                        IsServerCached = eq.Song?.Cached ?? false
                     };
 
                     queueDtos.Add(queueDto);
@@ -465,7 +467,8 @@ namespace BNKaraoke.Api.Controllers
                         WasSkipped = eq.WasSkipped,
                         IsCurrentlyPlaying = eq.IsCurrentlyPlaying,
                         SungAt = eq.SungAt,
-                        IsOnBreak = eq.IsOnBreak
+                        IsOnBreak = eq.IsOnBreak,
+                        IsServerCached = eq.Song?.Cached ?? false
                     };
                 }).ToList();
 
@@ -620,7 +623,8 @@ namespace BNKaraoke.Api.Controllers
                         WasSkipped = eq.WasSkipped,
                         IsCurrentlyPlaying = eq.IsCurrentlyPlaying,
                         SungAt = eq.SungAt,
-                        IsOnBreak = eq.IsOnBreak
+                        IsOnBreak = eq.IsOnBreak,
+                        IsServerCached = eq.Song?.Cached ?? false
                     };
                 }).ToList();
 
@@ -774,7 +778,8 @@ namespace BNKaraoke.Api.Controllers
                     WasSkipped = queueEntry.WasSkipped,
                     IsCurrentlyPlaying = queueEntry.IsCurrentlyPlaying,
                     SungAt = queueEntry.SungAt,
-                    IsOnBreak = queueEntry.IsOnBreak
+                    IsOnBreak = queueEntry.IsOnBreak,
+                    IsServerCached = queueEntry.Song?.Cached ?? false
                 };
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueEntryDto, "SingersUpdated");
@@ -873,7 +878,8 @@ namespace BNKaraoke.Api.Controllers
                     WasSkipped = queueEntry.WasSkipped,
                     IsCurrentlyPlaying = queueEntry.IsCurrentlyPlaying,
                     SungAt = queueEntry.SungAt,
-                    IsOnBreak = queueEntry.IsOnBreak
+                    IsOnBreak = queueEntry.IsOnBreak,
+                    IsServerCached = queueEntry.Song?.Cached ?? false
                 };
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueEntryDto, "Skipped");

--- a/BNKaraoke.Api/DTOs/EventDto.cs
+++ b/BNKaraoke.Api/DTOs/EventDto.cs
@@ -48,6 +48,7 @@ namespace BNKaraoke.Api.Dtos
         public bool IsSingerLoggedIn { get; set; }
         public bool IsSingerJoined { get; set; }
         public bool IsSingerOnBreak { get; set; }
+        public bool IsServerCached { get; set; }
     }
 
     public class EventQueueCreateDto

--- a/BNKaraoke.Api/Hubs/KaraokeDJHub.cs
+++ b/BNKaraoke.Api/Hubs/KaraokeDJHub.cs
@@ -114,7 +114,8 @@ namespace BNKaraoke.Api.Hubs
                                 IsUpNext = false,
                                 IsSingerLoggedIn = false, // Fetch if needed
                                 IsSingerJoined = false,
-                                IsSingerOnBreak = false
+                                IsSingerOnBreak = false,
+                                IsServerCached = eq.Song?.Cached ?? false
                             };
                         }).ToList();
 

--- a/BNKaraoke.DJ/Models/EventQueueDto.cs
+++ b/BNKaraoke.DJ/Models/EventQueueDto.cs
@@ -27,5 +27,6 @@ namespace BNKaraoke.DJ.Models
         public bool IsSingerLoggedIn { get; set; }
         public bool IsSingerJoined { get; set; }
         public bool IsSingerOnBreak { get; set; }
+        public bool IsServerCached { get; set; }
     }
 }

--- a/BNKaraoke.DJ/Models/QueueEntry.cs
+++ b/BNKaraoke.DJ/Models/QueueEntry.cs
@@ -28,6 +28,7 @@ namespace BNKaraoke.DJ.Models
         private string? _decade;
         private string? _youTubeUrl;
         private bool _isVideoCached;
+        private bool _isServerCached;
         private bool _isOnBreak;
         private bool _isOnHold;
         private bool _isUpNext;
@@ -199,6 +200,12 @@ namespace BNKaraoke.DJ.Models
         {
             get => _isVideoCached;
             set => SetProperty(ref _isVideoCached, value);
+        }
+
+        public bool IsServerCached
+        {
+            get => _isServerCached;
+            set => SetProperty(ref _isServerCached, value);
         }
 
         public bool IsOnBreak

--- a/BNKaraoke.DJ/Services/SignalRService.cs
+++ b/BNKaraoke.DJ/Services/SignalRService.cs
@@ -97,6 +97,10 @@ namespace BNKaraoke.DJ.Services
                 _connection.On<List<EventQueueDto>>("InitialQueue", (queue) =>
                 {
                     Log.Information("[SIGNALR] Received InitialQueue for EventId={EventId}, Count={Count}", _currentEventId, queue.Count);
+                    foreach (var item in queue)
+                    {
+                        Log.Debug("[SIGNALR] Queue item {QueueId} IsServerCached={IsServerCached}", item.QueueId, item.IsServerCached);
+                    }
                     _initialQueueCallback(queue);
                 });
 

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -544,14 +544,15 @@ namespace BNKaraoke.DJ.ViewModels
                         WasSkipped = dto.WasSkipped,
                         IsCurrentlyPlaying = dto.IsCurrentlyPlaying,
                         SungAt = dto.SungAt,
-                        IsOnBreak = dto.IsOnBreak,
-                        IsOnHold = !string.IsNullOrEmpty(dto.HoldReason),
-                        IsUpNext = dto.IsUpNext,
-                        HoldReason = dto.HoldReason,
-                        IsSingerLoggedIn = dto.IsSingerLoggedIn,
-                        IsSingerJoined = dto.IsSingerJoined,
-                        IsSingerOnBreak = dto.IsSingerOnBreak
-                    };
+                          IsOnBreak = dto.IsOnBreak,
+                          IsOnHold = !string.IsNullOrEmpty(dto.HoldReason),
+                          IsUpNext = dto.IsUpNext,
+                          HoldReason = dto.HoldReason,
+                          IsSingerLoggedIn = dto.IsSingerLoggedIn,
+                          IsSingerJoined = dto.IsSingerJoined,
+                          IsSingerOnBreak = dto.IsSingerOnBreak,
+                          IsServerCached = dto.IsServerCached
+                      };
                     // entry.IsVideoCached = _videoCacheService?.IsVideoCached(entry.SongId) ?? false;
                     QueueEntries.Add(entry);
                 }

--- a/bnkaraoke.web/src/hooks/useSignalR.ts
+++ b/bnkaraoke.web/src/hooks/useSignalR.ts
@@ -21,6 +21,7 @@ interface EventQueueDto {
   isCurrentlyPlaying: boolean;
   sungAt?: string;
   isOnBreak: boolean;
+  isServerCached: boolean;
 }
 
 interface UseSignalRProps {
@@ -185,6 +186,7 @@ const useSignalR = ({
       songTitle: dto.songTitle,
       songArtist: dto.songArtist,
       youTubeUrl: dto.youTubeUrl,
+      isServerCached: dto.isServerCached,
     };
   };
 

--- a/bnkaraoke.web/src/types.ts
+++ b/bnkaraoke.web/src/types.ts
@@ -101,6 +101,7 @@ export interface EventQueueItem {
   songTitle?: string;
   songArtist?: string;
   youTubeUrl?: string;
+  isServerCached: boolean;
 }
 
 export interface AttendanceAction {


### PR DESCRIPTION
## Summary
- add `IsServerCached` to queue DTOs and models
- populate `IsServerCached` in server-side queue constructors
- surface server cache status in SignalR handlers and client view models

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af89a1387883239a7226c3c44a6738