### PR TITLE
Add cache synchronization service

### DIFF
--- a/BNKaraoke.DJ/Services/ApiService.cs
+++ b/BNKaraoke.DJ/Services/ApiService.cs
@@ -538,6 +538,42 @@ namespace BNKaraoke.DJ.Services
                 throw;
             }
         }
+
+        public async Task<List<int>> GetCacheManifestAsync()
+        {
+            try
+            {
+                ConfigureAuthorizationHeader();
+                var response = await _httpClient.GetAsync("/api/cache/manifest");
+                response.EnsureSuccessStatusCode();
+                var manifest = await response.Content.ReadFromJsonAsync<List<int>>();
+                Log.Information("[APISERVICE] Fetched cache manifest with {Count} entries", manifest?.Count ?? 0);
+                return manifest ?? new List<int>();
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[APISERVICE] Failed to fetch cache manifest: {Message}", ex.Message);
+                return new List<int>();
+            }
+        }
+
+        public async Task<byte[]> GetCacheFileAsync(int songId)
+        {
+            try
+            {
+                ConfigureAuthorizationHeader();
+                var response = await _httpClient.GetAsync($"/api/cache/{songId}");
+                response.EnsureSuccessStatusCode();
+                var data = await response.Content.ReadAsByteArrayAsync();
+                Log.Information("[APISERVICE] Downloaded cache file for SongId={SongId} with {Length} bytes", songId, data.Length);
+                return data;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[APISERVICE] Failed to download cache file for SongId={SongId}: {Message}", songId, ex.Message);
+                throw;
+            }
+        }
     }
 
     public class SingerResponse

--- a/BNKaraoke.DJ/Services/CacheSyncService.cs
+++ b/BNKaraoke.DJ/Services/CacheSyncService.cs
@@ -1,0 +1,86 @@
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BNKaraoke.DJ.Services
+{
+    public class CacheSyncService
+    {
+        private readonly IApiService _apiService;
+        private readonly SettingsService _settingsService;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly ManualResetEventSlim _pauseEvent = new(true);
+        private Task? _syncTask;
+
+        public CacheSyncService(IApiService apiService, SettingsService settingsService)
+        {
+            _apiService = apiService ?? throw new ArgumentNullException(nameof(apiService));
+            _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+        }
+
+        public async Task<List<int>> GetDiff()
+        {
+            var manifest = await _apiService.GetCacheManifestAsync();
+            var cachePath = _settingsService.Settings.VideoCachePath;
+            Directory.CreateDirectory(cachePath);
+
+            var localIds = Directory.GetFiles(cachePath, "*.mp4")
+                .Select(Path.GetFileNameWithoutExtension)
+                .Select(f => int.TryParse(f, out var id) ? id : (int?)null)
+                .Where(id => id.HasValue)
+                .Select(id => id.Value)
+                .ToHashSet();
+
+            var missing = manifest.Where(id => !localIds.Contains(id)).ToList();
+            Log.Information("[CACHE SYNC] Computed diff: Manifest={ManifestCount}, Local={LocalCount}, Missing={MissingCount}", manifest.Count, localIds.Count, missing.Count);
+            return missing;
+        }
+
+        public Task StartSyncAsync()
+        {
+            _syncTask ??= Task.Run(async () =>
+            {
+                var diff = await GetDiff();
+                await DownloadMissingAsync(diff, _cts.Token);
+            }, _cts.Token);
+            return _syncTask;
+        }
+
+        public void Pause() => _pauseEvent.Reset();
+
+        public void Resume() => _pauseEvent.Set();
+
+        public void Cancel()
+        {
+            _cts.Cancel();
+            _pauseEvent.Set();
+        }
+
+        public async Task DownloadMissingAsync(IEnumerable<int> songIds, CancellationToken cancellationToken = default)
+        {
+            var cachePath = _settingsService.Settings.VideoCachePath;
+            Directory.CreateDirectory(cachePath);
+
+            foreach (var songId in songIds)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _pauseEvent.Wait(cancellationToken);
+                try
+                {
+                    var data = await _apiService.GetCacheFileAsync(songId);
+                    var filePath = Path.Combine(cachePath, $"{songId}.mp4");
+                    await File.WriteAllBytesAsync(filePath, data, cancellationToken);
+                    Log.Information("[CACHE SYNC] Downloaded song {SongId} to {Path}", songId, filePath);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error("[CACHE SYNC] Failed to download song {SongId}: {Message}", songId, ex.Message);
+                }
+            }
+        }
+    }
+}

--- a/BNKaraoke.DJ/Services/IApiService.cs
+++ b/BNKaraoke.DJ/Services/IApiService.cs
@@ -27,5 +27,7 @@ namespace BNKaraoke.DJ.Services
         Task ToggleBreakAsync(string eventId, int queueId, bool isOnBreak);
         Task UpdateSingerStatusAsync(string eventId, string requestorUserName, bool isLoggedIn, bool isJoined, bool isOnBreak);
         Task AddSongAsync(string eventId, int songId, string requestorUserName, string[] singers);
+        Task<List<int>> GetCacheManifestAsync();
+        Task<byte[]> GetCacheFileAsync(int songId);
     }
 }


### PR DESCRIPTION
## Summary
- add cache sync service to fetch cache manifest and download missing videos
- extend API service for cache manifest and cache file endpoints
- expose cache APIs through IApiService
- allow cache sync to run in background with pause/resume controls

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68afacf82c1883238e0a1e4a534956c9