### PR TITLE
Add cache manager window for song caching

### DIFF
--- a/BNKaraoke.DJ/ViewModels/CacheManagerViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/CacheManagerViewModel.cs
@@ -1,0 +1,75 @@
+using BNKaraoke.DJ.Services;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace BNKaraoke.DJ.ViewModels
+{
+    public partial class CacheManagerViewModel : ObservableObject
+    {
+        private readonly CacheSyncService _cacheSyncService;
+
+        public ObservableCollection<CacheItem> Songs { get; } = new();
+
+        public IRelayCommand CloseCommand { get; }
+        public IAsyncRelayCommand<CacheItem> DownloadCommand { get; }
+
+        public CacheManagerViewModel(CacheSyncService cacheSyncService)
+        {
+            _cacheSyncService = cacheSyncService;
+            CloseCommand = new RelayCommand<Window>(w => w.Close());
+            DownloadCommand = new AsyncRelayCommand<CacheItem>(DownloadAsync);
+        }
+
+        public async Task LoadAsync()
+        {
+            try
+            {
+                Songs.Clear();
+                var statuses = await _cacheSyncService.GetCacheStatusAsync();
+                foreach (var status in statuses)
+                {
+                    Songs.Add(new CacheItem
+                    {
+                        SongId = status.SongId,
+                        ServerCached = true,
+                        LocalCached = status.LocalCached
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[CACHEMANAGER] Failed to load cache status: {Message}", ex.Message);
+            }
+        }
+
+        private async Task DownloadAsync(CacheItem? item)
+        {
+            if (item == null || item.LocalCached) return;
+            try
+            {
+                await _cacheSyncService.DownloadMissingAsync(new[] { item.SongId });
+                item.LocalCached = true;
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[CACHEMANAGER] Failed to download song {SongId}: {Message}", item?.SongId, ex.Message);
+            }
+        }
+
+        public partial class CacheItem : ObservableObject
+        {
+            public int SongId { get; set; }
+
+            [ObservableProperty]
+            private bool serverCached;
+
+            [ObservableProperty]
+            private bool localCached;
+        }
+    }
+}

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Header.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Header.cs
@@ -352,6 +352,29 @@ namespace BNKaraoke.DJ.ViewModels
             }
         }
 
+        [RelayCommand]
+        private async Task OpenCacheManager()
+        {
+            Log.Information("[DJSCREEN] Cache manager button clicked");
+            try
+            {
+                var viewModel = new CacheManagerViewModel(_cacheSyncService);
+                await viewModel.LoadAsync();
+                var window = new CacheManagerWindow
+                {
+                    DataContext = viewModel,
+                    WindowStartupLocation = WindowStartupLocation.CenterScreen
+                };
+                window.ShowDialog();
+                Log.Information("[DJSCREEN] CacheManagerWindow closed");
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[DJSCREEN] Failed to open CacheManagerWindow: {Message}", ex.Message);
+                SetWarningMessage($"Failed to open cache manager: {ex.Message}");
+            }
+        }
+
         private async Task UpdateJoinEventButtonState()
         {
             try

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -21,6 +21,7 @@ namespace BNKaraoke.DJ.ViewModels
         private readonly SettingsService _settingsService = SettingsService.Instance;
         private readonly VideoCacheService? _videoCacheService;
         private readonly SignalRService? _signalRService;
+        private readonly CacheSyncService _cacheSyncService;
         private string? _currentEventId;
         private VideoPlayerWindow? _videoPlayerWindow;
         private bool _isLoginWindowOpen;
@@ -80,6 +81,7 @@ namespace BNKaraoke.DJ.ViewModels
                     HandleInitialQueue,
                     HandleInitialSingers
                 );
+                _cacheSyncService = new CacheSyncService(_apiService, _settingsService);
                 _userSessionService.SessionChanged += UserSessionService_SessionChanged;
                 Log.Information("[DJSCREEN VM] Subscribed to SessionChanged event");
                 ViewSungSongsCommand = new RelayCommand(ExecuteViewSungSongs);

--- a/BNKaraoke.DJ/Views/CacheManagerWindow.xaml
+++ b/BNKaraoke.DJ/Views/CacheManagerWindow.xaml
@@ -1,0 +1,29 @@
+<Window x:Class="BNKaraoke.DJ.Views.CacheManagerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Cache Manager" Width="600" Height="400" Background="#2D2D2D">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <DataGrid ItemsSource="{Binding Songs}" AutoGenerateColumns="False" Grid.Row="0" CanUserAddRows="False" Background="#333" Foreground="White">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Song" Binding="{Binding SongId}" Width="*"/>
+                <DataGridCheckBoxColumn Header="ServerCached" Binding="{Binding ServerCached}" IsReadOnly="True"/>
+                <DataGridCheckBoxColumn Header="LocalCached" Binding="{Binding LocalCached}" IsReadOnly="True"/>
+                <DataGridTemplateColumn Header="Action">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <Button Content="Download"
+                                    Command="{Binding DataContext.DownloadCommand, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                    CommandParameter="{Binding}"/>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+            </DataGrid.Columns>
+        </DataGrid>
+        <Button Grid.Row="1" Content="Close" Width="80" Height="30" HorizontalAlignment="Right" Margin="0,10,0,0"
+                Command="{Binding CloseCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>
+    </Grid>
+</Window>

--- a/BNKaraoke.DJ/Views/CacheManagerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/CacheManagerWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace BNKaraoke.DJ.Views
+{
+    public partial class CacheManagerWindow : Window
+    {
+        public CacheManagerWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -36,6 +36,8 @@
             <TextBlock Text="BNKaraoke.com DJ App" FontSize="28" FontWeight="Bold" Foreground="White"
                        VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Column="1"/>
             <DockPanel Grid.Column="2" Margin="0,0,0,0" HorizontalAlignment="Right">
+                <Button x:Name="CacheButton" Width="100" Height="40" Margin="5,0,0,0" Background="Blue"
+                        Content="Cache" Command="{Binding OpenCacheManagerCommand}" DockPanel.Dock="Right"/>
                 <Button x:Name="SettingsButton" Width="40" Height="40" Margin="5,0,0,0" Background="Blue"
                         Command="{Binding OpenSettingsCommand}" DockPanel.Dock="Right">
                     <Image Source="pack://application:,,,/Assets/gear3.png" Width="24" Height="24"/>


### PR DESCRIPTION
## Summary
- add CacheManager window and view model to inspect song cache status and download missing files
- expose cache manifest status from CacheSyncService
- wire DJ screen header button and command to open cache manager

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68afb07355d48323bf06b32d0222afe5