### PR TITLE
Add cache manifest model and streaming download

### DIFF
--- a/BNKaraoke.DJ/Models/CacheManifestItem.cs
+++ b/BNKaraoke.DJ/Models/CacheManifestItem.cs
@@ -1,0 +1,6 @@
+namespace BNKaraoke.DJ.Models;
+
+public class CacheManifestItem
+{
+    public int SongId { get; set; }
+}

--- a/BNKaraoke.DJ/Services/IApiService.cs
+++ b/BNKaraoke.DJ/Services/IApiService.cs
@@ -1,5 +1,6 @@
 using BNKaraoke.DJ.Models;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -27,7 +28,7 @@ namespace BNKaraoke.DJ.Services
         Task ToggleBreakAsync(string eventId, int queueId, bool isOnBreak);
         Task UpdateSingerStatusAsync(string eventId, string requestorUserName, bool isLoggedIn, bool isJoined, bool isOnBreak);
         Task AddSongAsync(string eventId, int songId, string requestorUserName, string[] singers);
-        Task<List<int>> GetCacheManifestAsync();
-        Task<byte[]> GetCacheFileAsync(int songId);
+        Task<List<CacheManifestItem>> GetCacheManifestAsync();
+        Task<Stream> DownloadCachedSongAsync(int songId);
     }
 }


### PR DESCRIPTION
## Summary
- add CacheManifestItem model and API signatures
- stream cached song downloads through ApiService
- refactor cache syncing to use new manifest items and streaming

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(command failed: command not found)*
- `apt-get update` *(error: repositories not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68afb21af1f08323952e5043eb8aac9e