### PR TITLE
Show server caching in queue entries

### DIFF
--- a/BNKaraoke.DJ/Services/ApiService.cs
+++ b/BNKaraoke.DJ/Services/ApiService.cs
@@ -213,7 +213,7 @@ namespace BNKaraoke.DJ.Services
             }
         }
 
-        public async Task<List<QueueEntry>> GetQueueAsync(string eventId)
+        public async Task<List<EventQueueDto>> GetQueueAsync(string eventId)
         {
             try
             {
@@ -224,16 +224,16 @@ namespace BNKaraoke.DJ.Services
                 {
                     var errorContent = await response.Content.ReadAsStringAsync();
                     Log.Error("[APISERVICE] Failed to fetch queue for event {EventId}: Status={StatusCode}, Message={Message}", eventId, response.StatusCode, errorContent);
-                    return new List<QueueEntry>();
+                    return new List<EventQueueDto>();
                 }
-                var queueResponse = await response.Content.ReadFromJsonAsync<List<QueueEntry>>();
+                var queueResponse = await response.Content.ReadFromJsonAsync<List<EventQueueDto>>();
                 Log.Information("[APISERVICE] Fetched {Count} queue entries for EventId={EventId}", queueResponse?.Count ?? 0, eventId);
-                return queueResponse ?? new List<QueueEntry>();
+                return queueResponse ?? new List<EventQueueDto>();
             }
             catch (JsonException ex)
             {
                 Log.Error("[APISERVICE] Failed to deserialize queue for EventId={EventId}: {Message}", ex.Message);
-                return new List<QueueEntry>();
+                return new List<EventQueueDto>();
             }
             catch (Exception ex)
             {

--- a/BNKaraoke.DJ/Services/IApiService.cs
+++ b/BNKaraoke.DJ/Services/IApiService.cs
@@ -14,7 +14,7 @@ namespace BNKaraoke.DJ.Services
         Task<string> GetDiagnosticAsync();
         Task<LoginResult> LoginAsync(string userName, string password);
         Task<List<Singer>> GetSingersAsync(string eventId);
-        Task<List<QueueEntry>> GetQueueAsync(string eventId);
+        Task<List<EventQueueDto>> GetQueueAsync(string eventId);
         Task<List<QueueEntry>> GetLiveQueueAsync(string eventId);
         Task<List<QueueEntry>> GetSungQueueAsync(string eventId);
         Task<int> GetSungCountAsync(string eventId);

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -216,6 +216,13 @@
                                             </DataTemplate>
                                         </GridViewColumn.CellTemplate>
                                     </GridViewColumn>
+                                    <GridViewColumn Header="Server" Width="60">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <CheckBox IsChecked="{Binding IsServerCached}" IsEnabled="False" HorizontalAlignment="Center"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
                                 </GridView>
                             </ListView.View>
                             <ListView.ItemContainerStyle>


### PR DESCRIPTION
## Summary
- display server cache status in the DJ queue list
- load IsServerCached from API EventQueueDto

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68afbfa4e6ac832380869fca1d230a68