### PR TITLE
Handle placeholder hold reason in queue entries

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -435,9 +435,13 @@ namespace BNKaraoke.DJ.ViewModels
                             IsCurrentlyPlaying = dto.IsCurrentlyPlaying,
                             SungAt = dto.SungAt,
                             IsOnBreak = dto.IsOnBreak,
-                            IsOnHold = !string.IsNullOrEmpty(dto.HoldReason),
+                            IsOnHold = !string.IsNullOrEmpty(dto.HoldReason) &&
+                                        !string.Equals(dto.HoldReason, "None", StringComparison.OrdinalIgnoreCase),
                             IsUpNext = dto.IsUpNext,
-                            HoldReason = dto.HoldReason,
+                            HoldReason = string.IsNullOrWhiteSpace(dto.HoldReason) ||
+                                         string.Equals(dto.HoldReason, "None", StringComparison.OrdinalIgnoreCase)
+                                            ? null
+                                            : dto.HoldReason,
                             IsSingerLoggedIn = dto.IsSingerLoggedIn,
                             IsSingerJoined = dto.IsSingerJoined,
                             IsSingerOnBreak = dto.IsSingerOnBreak,
@@ -570,9 +574,13 @@ namespace BNKaraoke.DJ.ViewModels
                         IsCurrentlyPlaying = dto.IsCurrentlyPlaying,
                         SungAt = dto.SungAt,
                           IsOnBreak = dto.IsOnBreak,
-                          IsOnHold = !string.IsNullOrEmpty(dto.HoldReason),
+                          IsOnHold = !string.IsNullOrEmpty(dto.HoldReason) &&
+                                        !string.Equals(dto.HoldReason, "None", StringComparison.OrdinalIgnoreCase),
                           IsUpNext = dto.IsUpNext,
-                          HoldReason = dto.HoldReason,
+                          HoldReason = string.IsNullOrWhiteSpace(dto.HoldReason) ||
+                                       string.Equals(dto.HoldReason, "None", StringComparison.OrdinalIgnoreCase)
+                                            ? null
+                                            : dto.HoldReason,
                           IsSingerLoggedIn = dto.IsSingerLoggedIn,
                           IsSingerJoined = dto.IsSingerJoined,
                           IsSingerOnBreak = dto.IsSingerOnBreak,


### PR DESCRIPTION
## Summary
- Normalize hold reason values so "None" doesn't mark songs as on hold
- Preserve hold reason only when a meaningful value exists

## Testing
- `dotnet build BNKaraoke.sln` *(fails: dotnet: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68afd5a8b0a88323a734ec294b39f2d1