### PR TITLE
feat: add yt-dlp timeout and api key support

### DIFF
--- a/Scripts/ApiMaintenance.sql
+++ b/Scripts/ApiMaintenance.sql
@@ -6,3 +6,7 @@ INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('CacheSt
 INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('CacheDownloadDelaySeconds', '5');
 -- Full path to the yt-dlp executable used for caching
 INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('YtDlpPath', '/usr/local/bin/yt-dlp');
+-- Maximum allowed runtime for yt-dlp in seconds
+INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('YtDlpTimeout', '600');
+-- Optional path to cookies file for yt-dlp to access age-restricted videos
+INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('YtDlpCookiesPath', '');


### PR DESCRIPTION
## Summary
- add configurable yt-dlp timeout and retry on timeout
- pass YouTube API key to yt-dlp via extractor args
- seed default YtDlpTimeout and cookies path settings
- allow yt-dlp cookies for age-restricted videos
- log age restriction warnings when download fails
- restore .gitignore to remove binary diff

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68b0618a4e388323bfe34d70a3c11cb7