### PR TITLE
Add mature indicator checkbox to DJ SignalR queue

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -296,7 +296,8 @@ namespace BNKaraoke.Api.Controllers
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
                     IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
-                    IsServerCached = queueEntry.Song?.Cached ?? false
+                    IsServerCached = queueEntry.Song?.Cached ?? false,
+                    IsMature = queueEntry.Song?.Mature ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDto, "Playing");
                 _logger.LogInformation("[DJController] Started play for QueueId: {QueueId} for EventId: {EventId}", queueId, eventId);
@@ -371,7 +372,8 @@ namespace BNKaraoke.Api.Controllers
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
                     IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
-                    IsServerCached = queueEntry.Song?.Cached ?? false
+                    IsServerCached = queueEntry.Song?.Cached ?? false,
+                    IsMature = queueEntry.Song?.Mature ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDto, "Skipped");
                 _logger.LogInformation("[DJController] Skipped song with QueueId: {QueueId} for EventId: {EventId}", queueId, eventId);
@@ -452,7 +454,8 @@ namespace BNKaraoke.Api.Controllers
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
                     IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
-                    IsServerCached = queueEntry.Song?.Cached ?? false
+                    IsServerCached = queueEntry.Song?.Cached ?? false,
+                    IsMature = queueEntry.Song?.Mature ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{queueEntry.EventId}").SendAsync("QueueUpdated", queueDto, "Playing");
                 _logger.LogInformation("[DJController] Set now playing for QueueId: {QueueId}, EventId: {EventId}", request.QueueId, queueEntry.EventId);
@@ -561,7 +564,8 @@ namespace BNKaraoke.Api.Controllers
                             IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                             IsSingerJoined = singerStatus?.IsJoined ?? false,
                             IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
-                            IsServerCached = entry.Song?.Cached ?? false
+                            IsServerCached = entry.Song?.Cached ?? false,
+                            IsMature = entry.Song?.Mature ?? false
                         };
                         await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueDto, "OnHold");
                     }
@@ -618,7 +622,8 @@ namespace BNKaraoke.Api.Controllers
                     IsSingerLoggedIn = nextSingerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = nextSingerStatus?.IsJoined ?? false,
                     IsSingerOnBreak = nextSingerStatus?.IsOnBreak ?? false,
-                    IsServerCached = nextEntry.Song?.Cached ?? false
+                    IsServerCached = nextEntry.Song?.Cached ?? false,
+                    IsMature = nextEntry.Song?.Mature ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", nextQueueDto, "Playing");
                 _logger.LogInformation("[DJController] Selected next song for autoplay: QueueId: {QueueId}, EventId: {EventId}", nextEntry.QueueId, eventId);
@@ -988,7 +993,8 @@ namespace BNKaraoke.Api.Controllers
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
                     IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
-                    IsServerCached = queueEntry.Song?.Cached ?? false
+                    IsServerCached = queueEntry.Song?.Cached ?? false,
+                    IsMature = queueEntry.Song?.Mature ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{request.EventId}").SendAsync("QueueUpdated", queueDto, "Sung");
                 _logger.LogInformation("[DJController] Completed song with QueueId: {QueueId} for EventId: {EventId}", request.QueueId, request.EventId);
@@ -1065,7 +1071,8 @@ namespace BNKaraoke.Api.Controllers
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
                     IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
-                    IsServerCached = queueEntry.Song?.Cached ?? false
+                    IsServerCached = queueEntry.Song?.Cached ?? false,
+                    IsMature = queueEntry.Song?.Mature ?? false
                 };
                 await _hubContext.Clients.Group($"Event_{request.EventId}").SendAsync("QueueUpdated", queueDto, request.IsOnBreak ? "OnHold" : "Eligible");
                 _logger.LogInformation("[DJController] Toggled break for QueueId: {QueueId} to IsOnBreak: {IsOnBreak} for EventId: {EventId}", request.QueueId, request.IsOnBreak, request.EventId);
@@ -1208,7 +1215,8 @@ namespace BNKaraoke.Api.Controllers
                             IsSingerLoggedIn = request.IsLoggedIn,
                             IsSingerJoined = request.IsJoined,
                             IsSingerOnBreak = request.IsOnBreak,
-                            IsServerCached = entry.Song?.Cached ?? false
+                            IsServerCached = entry.Song?.Cached ?? false,
+                            IsMature = entry.Song?.Mature ?? false
                         };
                         await _hubContext.Clients.Group($"Event_{request.EventId}").SendAsync("QueueUpdated", queueDto, !string.IsNullOrEmpty(holdReason) ? "Held" : "Eligible");
                     }
@@ -1352,7 +1360,8 @@ namespace BNKaraoke.Api.Controllers
                     IsSingerLoggedIn = singerStatus?.IsLoggedIn ?? false,
                     IsSingerJoined = singerStatus?.IsJoined ?? false,
                     IsSingerOnBreak = singerStatus?.IsOnBreak ?? false,
-                    IsServerCached = eq.Song?.Cached ?? false
+                    IsServerCached = eq.Song?.Cached ?? false,
+                    IsMature = eq.Song?.Mature ?? false
                 };
                 queueDtos.Add(queueDto);
             }

--- a/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
+++ b/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
@@ -163,7 +163,8 @@ namespace BNKaraoke.Api.Controllers
                     IsCurrentlyPlaying = newQueueEntry.IsCurrentlyPlaying,
                     SungAt = newQueueEntry.SungAt,
                     IsOnBreak = newQueueEntry.IsOnBreak,
-                    IsServerCached = song.Cached
+                    IsServerCached = song.Cached,
+                    IsMature = song.Mature
                 };
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueEntryDto, "Added");
@@ -310,7 +311,8 @@ namespace BNKaraoke.Api.Controllers
                         IsCurrentlyPlaying = eq.IsCurrentlyPlaying,
                         SungAt = eq.SungAt,
                         IsOnBreak = eq.IsOnBreak,
-                        IsServerCached = eq.Song?.Cached ?? false
+                        IsServerCached = eq.Song?.Cached ?? false,
+                        IsMature = eq.Song?.Mature ?? false
                     };
 
                     queueDtos.Add(queueDto);
@@ -468,7 +470,8 @@ namespace BNKaraoke.Api.Controllers
                         IsCurrentlyPlaying = eq.IsCurrentlyPlaying,
                         SungAt = eq.SungAt,
                         IsOnBreak = eq.IsOnBreak,
-                        IsServerCached = eq.Song?.Cached ?? false
+                        IsServerCached = eq.Song?.Cached ?? false,
+                        IsMature = eq.Song?.Mature ?? false
                     };
                 }).ToList();
 
@@ -624,7 +627,8 @@ namespace BNKaraoke.Api.Controllers
                         IsCurrentlyPlaying = eq.IsCurrentlyPlaying,
                         SungAt = eq.SungAt,
                         IsOnBreak = eq.IsOnBreak,
-                        IsServerCached = eq.Song?.Cached ?? false
+                        IsServerCached = eq.Song?.Cached ?? false,
+                        IsMature = eq.Song?.Mature ?? false
                     };
                 }).ToList();
 
@@ -779,7 +783,8 @@ namespace BNKaraoke.Api.Controllers
                     IsCurrentlyPlaying = queueEntry.IsCurrentlyPlaying,
                     SungAt = queueEntry.SungAt,
                     IsOnBreak = queueEntry.IsOnBreak,
-                    IsServerCached = queueEntry.Song?.Cached ?? false
+                    IsServerCached = queueEntry.Song?.Cached ?? false,
+                    IsMature = queueEntry.Song?.Mature ?? false
                 };
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueEntryDto, "SingersUpdated");
@@ -879,7 +884,8 @@ namespace BNKaraoke.Api.Controllers
                     IsCurrentlyPlaying = queueEntry.IsCurrentlyPlaying,
                     SungAt = queueEntry.SungAt,
                     IsOnBreak = queueEntry.IsOnBreak,
-                    IsServerCached = queueEntry.Song?.Cached ?? false
+                    IsServerCached = queueEntry.Song?.Cached ?? false,
+                    IsMature = queueEntry.Song?.Mature ?? false
                 };
 
                 await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", queueEntryDto, "Skipped");

--- a/BNKaraoke.Api/DTOs/EventDto.cs
+++ b/BNKaraoke.Api/DTOs/EventDto.cs
@@ -49,6 +49,7 @@ namespace BNKaraoke.Api.Dtos
         public bool IsSingerJoined { get; set; }
         public bool IsSingerOnBreak { get; set; }
         public bool IsServerCached { get; set; }
+        public bool IsMature { get; set; }
     }
 
     public class EventQueueCreateDto

--- a/BNKaraoke.Api/Hubs/KaraokeDJHub.cs
+++ b/BNKaraoke.Api/Hubs/KaraokeDJHub.cs
@@ -115,7 +115,8 @@ namespace BNKaraoke.Api.Hubs
                                 IsSingerLoggedIn = false, // Fetch if needed
                                 IsSingerJoined = false,
                                 IsSingerOnBreak = false,
-                                IsServerCached = eq.Song?.Cached ?? false
+                                IsServerCached = eq.Song?.Cached ?? false,
+                                IsMature = eq.Song?.Mature ?? false
                             };
                         }).ToList();
 

--- a/BNKaraoke.DJ/Models/EventQueueDto.cs
+++ b/BNKaraoke.DJ/Models/EventQueueDto.cs
@@ -28,5 +28,6 @@ namespace BNKaraoke.DJ.Models
         public bool IsSingerJoined { get; set; }
         public bool IsSingerOnBreak { get; set; }
         public bool IsServerCached { get; set; }
+        public bool IsMature { get; set; }
     }
 }

--- a/BNKaraoke.DJ/Models/QueueEntry.cs
+++ b/BNKaraoke.DJ/Models/QueueEntry.cs
@@ -29,6 +29,7 @@ namespace BNKaraoke.DJ.Models
         private string? _youTubeUrl;
         private bool _isVideoCached;
         private bool _isServerCached;
+        private bool _isMature;
         private bool _isOnBreak;
         private bool _isOnHold;
         private bool _isUpNext;
@@ -206,6 +207,12 @@ namespace BNKaraoke.DJ.Models
         {
             get => _isServerCached;
             set => SetProperty(ref _isServerCached, value);
+        }
+
+        public bool IsMature
+        {
+            get => _isMature;
+            set => SetProperty(ref _isMature, value);
         }
 
         public bool IsOnBreak

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -584,7 +584,8 @@ namespace BNKaraoke.DJ.ViewModels
                           IsSingerLoggedIn = dto.IsSingerLoggedIn,
                           IsSingerJoined = dto.IsSingerJoined,
                           IsSingerOnBreak = dto.IsSingerOnBreak,
-                          IsServerCached = dto.IsServerCached
+                          IsServerCached = dto.IsServerCached,
+                          IsMature = dto.IsMature
                       };
                     // entry.IsVideoCached = _videoCacheService?.IsVideoCached(entry.SongId) ?? false;
                     QueueEntries.Add(entry);

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -223,6 +223,13 @@
                                             </DataTemplate>
                                         </GridViewColumn.CellTemplate>
                                     </GridViewColumn>
+                                    <GridViewColumn Header="Mature" Width="60">
+                                        <GridViewColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <CheckBox IsChecked="{Binding IsMature}" IsEnabled="False" HorizontalAlignment="Center"/>
+                                            </DataTemplate>
+                                        </GridViewColumn.CellTemplate>
+                                    </GridViewColumn>
                                 </GridView>
                             </ListView.View>
                             <ListView.ItemContainerStyle>


### PR DESCRIPTION
## Summary
- show song maturity in DJ queue with new checkbox column
- plumb IsMature through QueueEntry and EventQueueDto
- expose maturity flag from API controllers and SignalR hub

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c365165c832393ba76fffd65a7fe