### PR TITLE
Show mature uncached songs and improve caching quality

### DIFF
--- a/BNKaraoke.Api/Services/SongCacheService.cs
+++ b/BNKaraoke.Api/Services/SongCacheService.cs
@@ -98,7 +98,9 @@ namespace BNKaraoke.Api.Services
                     ? ytDlpPath
                     : (OperatingSystem.IsWindows() ? "yt-dlp.exe" : "yt-dlp");
                 var apiKey = _configuration["YouTube:ApiKey"];
-                var arguments = $"--output \"{filePath}\" -f mp4 \"{youTubeUrl}\"";
+                // Download best available MP4 video with AAC audio for high-quality playback
+                var arguments =
+                    $"--output \"{filePath}\" -f \"bestvideo[ext=mp4]+bestaudio[ext=m4a]/b[ext=mp4]\" --merge-output-format mp4 \"{youTubeUrl}\"";
                 if (!string.IsNullOrWhiteSpace(apiKey))
                 {
                     arguments += $" --extractor-args \"youtube:api_key={apiKey}\"";

--- a/bnkaraoke.web/src/config/apiConfig.ts
+++ b/bnkaraoke.web/src/config/apiConfig.ts
@@ -53,6 +53,7 @@ export const API_ROUTES = {
   API_MANUAL_CACHE_START: `${API_BASE_URL}/api/maintenance/manual-cache/start`,
   API_MANUAL_CACHE_STOP: `${API_BASE_URL}/api/maintenance/manual-cache/stop`,
   API_MANUAL_CACHE_STATUS: `${API_BASE_URL}/api/maintenance/manual-cache/status`,
+  API_MATURE_NOT_CACHED: `${API_BASE_URL}/api/maintenance/mature-not-cached`,
 };
 
 export default API_BASE_URL;

--- a/bnkaraoke.web/src/pages/ApiMaintenancePage.tsx
+++ b/bnkaraoke.web/src/pages/ApiMaintenancePage.tsx
@@ -7,11 +7,19 @@ interface ApiSetting {
   settingValue: string;
 }
 
+interface MatureSong {
+  id: number;
+  title: string;
+  artist: string;
+  youTubeUrl: string;
+}
+
 const ApiMaintenancePage: React.FC = () => {
   const [settings, setSettings] = useState<ApiSetting[]>([]);
   const [newKey, setNewKey] = useState("");
   const [newValue, setNewValue] = useState("");
   const [status, setStatus] = useState<string>("");
+  const [matureSongs, setMatureSongs] = useState<MatureSong[]>([]);
 
   const token = localStorage.getItem("token") || "";
 
@@ -25,8 +33,19 @@ const ApiMaintenancePage: React.FC = () => {
     }
   };
 
+  const fetchMatureSongs = async () => {
+    const res = await fetch(API_ROUTES.API_MATURE_NOT_CACHED, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setMatureSongs(data);
+    }
+  };
+
   useEffect(() => {
     fetchSettings();
+    fetchMatureSongs();
   }, []);
 
   const addSetting = async () => {
@@ -163,6 +182,32 @@ const ApiMaintenancePage: React.FC = () => {
       <button onClick={stopManual}>Stop Manual Cache</button>
       <button onClick={checkStatus}>Check Status</button>
       <p>{status}</p>
+      <h4>Mature Songs Not Cached</h4>
+      <button onClick={fetchMatureSongs}>Refresh</button>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Title</th>
+            <th>Artist</th>
+            <th>YouTube URL</th>
+          </tr>
+        </thead>
+        <tbody>
+          {matureSongs.map((s) => (
+            <tr key={s.id}>
+              <td>{s.id}</td>
+              <td>{s.title}</td>
+              <td>{s.artist}</td>
+              <td>
+                <a href={s.youTubeUrl} target="_blank" rel="noopener noreferrer">
+                  {s.youTubeUrl}
+                </a>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Enhance yt-dlp arguments to download high-quality MP4 video with AAC audio for song caching
- Expose `mature-not-cached` API route in frontend config
- Display list of mature songs that are not cached in API Maintenance cache tools

## Testing
- `dotnet build BNKaraoke.Api/BNKaraoke.Api.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repositories)*
- `npm test --prefix bnkaraoke.web -- --watchAll=false` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d8362c9883239f13e5a75d6f4ebd