### PR TITLE
feat: split pending song management

### DIFF
--- a/bnkaraoke.web/src/App.tsx
+++ b/bnkaraoke.web/src/App.tsx
@@ -7,6 +7,7 @@ import SpotifySearchTest from './pages/SpotifySearchTest';
 import PendingRequests from './pages/PendingRequests';
 import RequestSongPage from './pages/RequestSongPage';
 import SongManagerPage from './pages/SongManagerPage';
+import PendingSongManagerPage from './pages/PendingSongManagerPage';
 import UserManagementPage from './pages/UserManagementPage';
 import EventManagementPage from './pages/EventManagement';
 import Header from './components/Header';
@@ -212,6 +213,7 @@ const App: React.FC = () => {
                 <Route path="/spotify-search" element={<HeaderWrapper><SpotifySearchTest /></HeaderWrapper>} />
                 <Route path="/pending-requests" element={<HeaderWrapper><PendingRequests /></HeaderWrapper>} />
                 <Route path="/song-manager" element={<HeaderWrapper><SongManagerPage /></HeaderWrapper>} />
+                <Route path="/pending-song-manager" element={<HeaderWrapper><PendingSongManagerPage /></HeaderWrapper>} />
                 <Route path="/user-management" element={<HeaderWrapper><UserManagementPage /></HeaderWrapper>} />
                 <Route path="/event-management" element={<HeaderWrapper><EventManagementPage /></HeaderWrapper>} />
                 <Route path="/explore-songs" element={<HeaderWrapper><ExploreSongs /></HeaderWrapper>} />

--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -532,6 +532,15 @@ const Header: React.FC = memo(() => {
                       Manage Songs
                     </li>
                   )}
+                  {(roles.includes("Song Manager") || roles.includes("Queue Manager") || roles.includes("Application Manager")) && (
+                    <li
+                      className="dropdown-item"
+                      onClick={() => handleNavigation("/pending-song-manager")}
+                      onTouchStart={() => handleNavigation("/pending-song-manager")}
+                    >
+                      Manage Pending Songs
+                    </li>
+                  )}
                   {(roles.includes("User Manager") || roles.includes("Application Manager")) && (
                     <li
                       className="dropdown-item"
@@ -768,6 +777,15 @@ const Header: React.FC = memo(() => {
                     onTouchStart={() => handleNavigation("/song-manager")}
                   >
                     Manage Songs
+                  </li>
+                )}
+                {(roles.includes("Song Manager") || roles.includes("Queue Manager") || roles.includes("Application Manager")) && (
+                  <li
+                    className="dropdown-item"
+                    onClick={() => handleNavigation("/pending-song-manager")}
+                    onTouchStart={() => handleNavigation("/pending-song-manager")}
+                  >
+                    Manage Pending Songs
                   </li>
                 )}
                 {(roles.includes("User Manager") || roles.includes("Application Manager")) && (

--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.css
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.css
@@ -1,0 +1,514 @@
+/* src/pages/PendingSongManagerPage.css */
+.song-manager-container {
+  background: linear-gradient(to bottom, #1e3a8a, #3b82f6);
+  color: #ffffff;
+  min-height: 100vh;
+  padding: 20px;
+  font-family: Arial, sans-serif;
+}
+
+.song-manager-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 15px 30px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 10px;
+  margin-bottom: 20px;
+  box-shadow: 0 0 20px rgba(34, 211, 238, 0.5);
+}
+
+.song-manager-title {
+  font-size: 2rem;
+  font-weight: bold;
+  text-shadow: 0 0 10px #22d3ee;
+  margin: 0;
+}
+
+.header-buttons {
+  display: flex;
+  gap: 10px;
+}
+
+.song-manager-button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 5px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 0 10px rgba(34, 211, 238, 0.5);
+}
+
+.channels-button {
+  background: #22d3ee;
+  color: black;
+}
+
+.channels-button:hover {
+  background: #06b6d4;
+  box-shadow: 0 0 15px #22d3ee;
+}
+
+.back-button {
+  background: #6c757d;
+  color: white;
+}
+
+.back-button:hover {
+  background: #5a6268;
+  box-shadow: 0 0 15px #6c757d;
+}
+
+.song-manager-content {
+  max-width: 1400px;
+  margin: 0 auto;
+}
+
+.song-manager-sections {
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+}
+
+.song-manager-card, .song-editor-card {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 10px;
+  padding: 20px;
+  box-shadow: 0 0 20px rgba(34, 211, 238, 0.5);
+}
+
+.section-title {
+  font-size: 1.5rem;
+  margin-bottom: 15px;
+  text-shadow: 0 0 10px #22d3ee;
+}
+
+.song-list {
+  list-style: none;
+  padding: 0;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.song-item {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 15px;
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: transform 0.2s ease;
+}
+
+.song-item:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 0 15px rgba(34, 211, 238, 0.3);
+}
+
+.song-info {
+  flex: 1;
+}
+
+.song-title {
+  font-size: 1.2rem;
+  margin: 0;
+  color: #22d3ee;
+}
+
+.song-text {
+  font-size: 0.9rem;
+  color: #cccccc;
+  margin: 5px 0 0;
+}
+
+.song-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.find-button, .approve-button {
+  background: #22d3ee;
+  color: black;
+}
+
+.find-button:hover, .approve-button:hover {
+  background: #06b6d4;
+  box-shadow: 0 0 15px #22d3ee;
+}
+
+.manual-button, .preview-button {
+  background: #22d3ee;
+  color: black;
+}
+
+.manual-button:hover, .preview-button:hover {
+  background: #06b6d4;
+  box-shadow: 0 0 15px #22d3ee;
+}
+
+.reject-button, .delete-button, .close-button {
+  background: #f97316;
+  color: white;
+}
+
+.reject-button:hover, .delete-button:hover, .close-button:hover {
+  background: #e06614;
+  box-shadow: 0 0 15px #f97316;
+}
+
+.edit-button, .filter-button, .save-button {
+  background: #22d3ee;
+  color: black;
+}
+
+.edit-button:hover, .filter-button:hover, .save-button:hover {
+  background: #06b6d4;
+  box-shadow: 0 0 15px #22d3ee;
+}
+
+.clear-url-button {
+  background: #22d3ee;
+  color: black;
+}
+
+.clear-url-button:hover {
+  background: #06b6d4;
+  box-shadow: 0 0 15px #22d3ee;
+}
+
+.manual-link-input {
+  margin-top: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+.song-manager-input {
+  padding: 8px;
+  border: none;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #333;
+  font-size: 0.9rem;
+  width: 100%;
+}
+
+.song-manager-input:focus {
+  outline: none;
+  box-shadow: 0 0 10px #22d3ee;
+}
+
+.filter-section {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+  flex-wrap: wrap;
+}
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 10px;
+  padding: 20px;
+  max-width: 600px;
+  width: 90%;
+  box-shadow: 0 0 20px rgba(34, 211, 238, 0.5);
+  color: white;
+}
+
+.youtube-modal {
+  width: 80vw;
+  max-width: 1600px;
+}
+
+.youtube-modal-content {
+  display: flex;
+  gap: 20px;
+  width: 100%;
+}
+
+.youtube-list {
+  width: 70%;
+  min-width: 65%;
+  flex: none;
+  max-height: 600px;
+  overflow-y: auto;
+}
+
+.youtube-results {
+  list-style: none;
+  padding: 0;
+}
+
+.youtube-item {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 10px;
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.youtube-info {
+  flex: 1;
+}
+
+.youtube-title {
+  font-size: 1rem;
+  margin: 0;
+  color: #22d3ee;
+}
+
+.youtube-meta {
+  font-size: 0.8rem;
+  color: #cccccc;
+  margin: 3px 0 0;
+}
+
+.youtube-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.youtube-preview {
+  width: 30%;
+  min-width: 25%;
+  flex: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: rgba(0, 0, 0, 0.3);
+}
+
+.youtube-fallback {
+  text-align: center;
+}
+
+.watch-link {
+  color: #22d3ee;
+  text-decoration: none;
+}
+
+.watch-link:hover {
+  text-decoration: underline;
+}
+
+.modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 15px;
+}
+
+.error-text {
+  color: #f97316;
+  font-size: 0.9rem;
+  margin: 10px 0;
+}
+
+.song-text {
+  font-size: 0.9rem;
+  color: #cccccc;
+}
+
+/* Tablet (max-width: 991px) */
+@media (max-width: 991px) {
+  .song-manager-container.mobile-song-manager {
+    padding: 15px;
+  }
+  .song-manager-header {
+    padding: 12px 20px;
+    margin-bottom: 15px;
+  }
+  .song-manager-title {
+    font-size: 1.8rem;
+  }
+  .header-buttons {
+    gap: 8px;
+  }
+  .song-manager-button {
+    padding: 8px 16px;
+    font-size: 0.95rem;
+    min-height: 44px;
+  }
+  .song-manager-sections {
+    gap: 15px;
+  }
+  .song-manager-card, .song-editor-card {
+    padding: 15px;
+  }
+  .section-title {
+    font-size: 1.4rem;
+  }
+  .song-list {
+    max-height: 350px;
+  }
+  .song-item {
+    padding: 12px;
+  }
+  .song-title {
+    font-size: 1.1rem;
+  }
+  .song-text {
+    font-size: 0.85rem;
+  }
+  .filter-section {
+    gap: 8px;
+  }
+  .song-manager-input {
+    padding: 6px;
+    font-size: 0.85rem;
+  }
+  .youtube-modal {
+    width: 85vw;
+  }
+  .youtube-list {
+    max-height: 500px;
+  }
+  .youtube-preview iframe {
+    width: 100%;
+    max-width: 250px;
+    height: auto;
+    aspect-ratio: 16 / 9;
+  }
+  .modal-content {
+    max-width: 80%;
+    padding: 15px;
+  }
+  .modal-title {
+    font-size: 1.4rem;
+  }
+}
+
+/* Phone (max-width: 767px) */
+@media (max-width: 767px) {
+  .song-manager-container.mobile-song-manager {
+    padding: 10px;
+  }
+  .song-manager-header {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 10px;
+  }
+  .song-manager-title {
+    font-size: 1.6rem;
+  }
+  .header-buttons {
+    flex-direction: column;
+    width: 100%;
+    gap: 6px;
+  }
+  .song-manager-button {
+    padding: 6px 12px;
+    font-size: 0.9rem;
+    min-height: 44px;
+    width: 100%;
+  }
+  .song-manager-sections {
+    flex-direction: column;
+    gap: 10px;
+  }
+  .song-manager-card, .song-editor-card {
+    padding: 10px;
+  }
+  .section-title {
+    font-size: 1.3rem;
+  }
+  .song-list {
+    max-height: 300px;
+  }
+  .song-item {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 10px;
+  }
+  .song-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+  .song-title {
+    font-size: 1rem;
+  }
+  .song-text {
+    font-size: 0.8rem;
+  }
+  .filter-section {
+    flex-direction: column;
+    gap: 6px;
+  }
+  .song-manager-input {
+    padding: 5px;
+    font-size: 0.8rem;
+  }
+  .youtube-modal {
+    width: 95vw;
+  }
+  .youtube-modal-content {
+    flex-direction: column;
+  }
+  .youtube-list, .youtube-preview {
+    width: 100%;
+    min-width: 0;
+  }
+  .youtube-preview iframe {
+    width: 100%;
+    height: auto;
+    aspect-ratio: 16 / 9;
+  }
+  .modal-content {
+    max-width: 95%;
+    padding: 10px;
+  }
+  .modal-title {
+    font-size: 1.3rem;
+  }
+} 
+
+/* Enlarged styling for PendingSongManagerPage */
+.pending-song-manager .song-manager-card {
+  padding: 40px;
+}
+
+.pending-song-manager .song-list {
+  max-height: 800px;
+}
+
+.pending-song-manager .song-item {
+  padding: 30px;
+  margin-bottom: 20px;
+}
+
+.pending-song-manager .modal-content {
+  max-width: 1200px;
+  padding: 40px;
+}
+
+.pending-song-manager .youtube-modal {
+  width: 90vw;
+  max-width: 3200px;
+}
+
+.pending-song-manager .youtube-list {
+  max-height: 1200px;
+}
+
+.pending-song-manager .youtube-preview iframe {
+  width: 600px;
+  height: 338px;
+}

--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
@@ -1,0 +1,463 @@
+// src/pages/PendingSongManagerPage.tsx
+import React, { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { API_ROUTES } from "../config/apiConfig";
+import "./PendingSongManagerPage.css";
+
+interface PendingSong {
+  id: number;
+  title: string;
+  artist: string;
+  genre: string;
+  status: string;
+  requestDate: string;
+  spotifyId: string | null;
+  firstName: string;
+  lastName: string;
+}
+
+interface YouTubeVideo {
+  videoId: string;
+  title: string;
+  url: string;
+  channelTitle: string;
+  duration: string;
+  uploadDate: string;
+  viewCount: number;
+}
+
+interface KaraokeChannel {
+  Id: number;
+  ChannelName: string;
+  ChannelId: string | null;
+  SortOrder: number;
+  IsActive: boolean;
+}
+
+const PendingSongManagerPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [pendingSongs, setPendingSongs] = useState<PendingSong[]>([]);
+  const [youtubeResults, setYoutubeResults] = useState<YouTubeVideo[]>([]);
+  const [selectedSongId, setSelectedSongId] = useState<number | null>(null);
+  const [manualLinks, setManualLinks] = useState<{ [key: number]: string }>({});
+  const [showManualInput, setShowManualInput] = useState<{ [key: number]: boolean }>({});
+  const [selectedVideo, setSelectedVideo] = useState<{ videoId: string; url: string } | null>(null);
+  const [isVideoEmbeddable, setIsVideoEmbeddable] = useState<boolean>(true);
+  const [showYoutubeModal, setShowYoutubeModal] = useState(false);
+  const [karaokeChannels, setKaraokeChannels] = useState<KaraokeChannel[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [youtubeError, setYoutubeError] = useState<string | null>(null);
+
+  const validateToken = () => {
+    const token = localStorage.getItem("token");
+    const userName = localStorage.getItem("userName");
+    if (!token || !userName) {
+      setError("Authentication token or username missing. Please log in again.");
+      navigate("/login");
+      return null;
+    }
+
+    try {
+      if (token.split(".").length !== 3) {
+        localStorage.removeItem("token");
+        localStorage.removeItem("userName");
+        setError("Invalid token format. Please log in again.");
+        navigate("/login");
+        return null;
+      }
+
+      const payload = JSON.parse(atob(token.split(".")[1]));
+      const exp = payload.exp * 1000;
+      if (exp < Date.now()) {
+        localStorage.removeItem("token");
+        localStorage.removeItem("userName");
+        setError("Session expired. Please log in again.");
+        navigate("/login");
+        return null;
+      }
+      return token;
+    } catch (err) {
+      localStorage.removeItem("token");
+      localStorage.removeItem("userName");
+      setError("Invalid token. Please log in again.");
+      navigate("/login");
+      return null;
+    }
+  };
+
+  const fetchKaraokeChannels = useCallback(async (token: string) => {
+    try {
+      const response = await fetch(API_ROUTES.KARAOKE_CHANNELS, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch karaoke channels: ${response.status} ${response.statusText}`);
+      }
+      const data: KaraokeChannel[] = await response.json();
+      setKaraokeChannels(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+    }
+  }, []);
+
+  const fetchPendingSongs = useCallback(async (token: string) => {
+    try {
+      const response = await fetch(API_ROUTES.PENDING_SONGS, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(`Failed to fetch pending songs: ${response.status} ${response.statusText} - ${text}`);
+      }
+      setPendingSongs(JSON.parse(text));
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setPendingSongs([]);
+      setError(message);
+    }
+  }, []);
+
+  useEffect(() => {
+    const token = validateToken();
+    if (!token) return;
+
+    const storedRoles = localStorage.getItem("roles");
+    if (storedRoles) {
+      const parsedRoles = JSON.parse(storedRoles);
+      if (!parsedRoles.includes("Song Manager")) {
+        navigate("/dashboard");
+        return;
+      }
+    } else {
+      navigate("/login");
+      return;
+    }
+
+    fetchPendingSongs(token);
+    fetchKaraokeChannels(token);
+  }, [navigate, fetchPendingSongs, fetchKaraokeChannels]);
+
+  const handleYoutubeSearch = async (songId: number, title: string, artist: string, token: string) => {
+    try {
+      const query = `Karaoke ${title} ${artist}`;
+      const response = await fetch(`${API_ROUTES.YOUTUBE_SEARCH}?query=${encodeURIComponent(query)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(`Failed to search YouTube: ${response.status} ${response.statusText} - ${text}`);
+      }
+      const data: YouTubeVideo[] = JSON.parse(text);
+      const sorted = data.sort((a, b) => {
+        const aChannel = karaokeChannels.find(c => c.ChannelName === a.channelTitle);
+        const bChannel = karaokeChannels.find(c => c.ChannelName === b.channelTitle);
+        const aOrder = aChannel ? aChannel.SortOrder : Number.MAX_SAFE_INTEGER;
+        const bOrder = bChannel ? bChannel.SortOrder : Number.MAX_SAFE_INTEGER;
+        return aOrder - bOrder;
+      });
+      setYoutubeResults(sorted);
+      setSelectedSongId(songId);
+      setSelectedVideo(null);
+      setIsVideoEmbeddable(true);
+      setShowYoutubeModal(true);
+      setYoutubeError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setYoutubeError(message);
+      setYoutubeResults([]);
+      setSelectedSongId(songId);
+      setSelectedVideo(null);
+      setIsVideoEmbeddable(true);
+      setShowYoutubeModal(true);
+    }
+  };
+
+  const handlePreviewVideo = (videoId: string, url: string) => {
+    setSelectedVideo({ videoId, url });
+    setIsVideoEmbeddable(true);
+  };
+
+  const handleIframeError = () => {
+    setIsVideoEmbeddable(false);
+  };
+
+  const formatDuration = (isoDuration: string): string => {
+    const match = isoDuration.match(/PT(?:\d+H)?(?:\d+M)?(?:\d+S)?/);
+    if (!match) return "0:00";
+    const hours = parseInt(match[0].match(/(\d+)H/)?.[1] || "0", 10);
+    const minutes = parseInt(match[0].match(/(\d+)M/)?.[1] || "0", 10);
+    const seconds = parseInt(match[0].match(/(\d+)S/)?.[1] || "0", 10);
+    if (hours > 0) {
+      return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+    }
+    return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  };
+
+  const formatDate = (isoDate: string): string => {
+    const date = new Date(isoDate);
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  };
+
+  const formatViewCount = (count: number): string => {
+    if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+    if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+    return count.toString();
+  };
+
+  const handleApproveSong = async (songId: number, YouTubeUrl: string, token: string) => {
+    try {
+      const response = await fetch(API_ROUTES.APPROVE_SONGS, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id: songId, YouTubeUrl }),
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(`Failed to approve song: ${response.status} ${response.statusText} - ${text}`);
+      }
+      alert("Song approved successfully!");
+      fetchPendingSongs(token);
+      setShowManualInput(prev => ({ ...prev, [songId]: false }));
+      setShowYoutubeModal(false);
+      setYoutubeResults([]);
+      setSelectedVideo(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+    }
+  };
+
+  const handleRejectSong = async (songId: number, token: string) => {
+    try {
+      const response = await fetch(API_ROUTES.REJECT_SONG, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ id: songId }),
+      });
+      const text = await response.text();
+      if (!response.ok) {
+        throw new Error(`Failed to reject song: ${response.status} ${response.statusText} - ${text}`);
+      }
+      alert("Song rejected successfully!");
+      fetchPendingSongs(token);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+    }
+  };
+
+  const toggleManualInput = (songId: number) => {
+    setShowManualInput(prev => ({ ...prev, [songId]: !prev[songId] }));
+  };
+
+  const handleManualLinkChange = (songId: number, value: string) => {
+    setManualLinks(prev => ({ ...prev, [songId]: value }));
+  };
+
+  return (
+    <div className="song-manager-container pending-song-manager">
+      <header className="song-manager-header">
+        <h1 className="song-manager-title">Pending Song Manager</h1>
+        <div className="header-buttons">
+          <button
+            className="song-manager-button channels-button"
+            onClick={() => navigate("/karaoke-channels")}
+            onTouchStart={() => navigate("/karaoke-channels")}
+          >
+            Manage Channels
+          </button>
+          <button
+            className="song-manager-button back-button"
+            onClick={() => navigate("/dashboard")}
+            onTouchStart={() => navigate("/dashboard")}
+          >
+            Back to Dashboard
+          </button>
+        </div>
+      </header>
+
+      <div className="song-manager-content">
+        <section className="song-manager-card">
+          <h2 className="section-title">Pending Songs</h2>
+          {error && <p className="error-text">{error}</p>}
+          {pendingSongs.length > 0 ? (
+            <ul className="song-list">
+              {pendingSongs.map(song => (
+                <li key={song.id} className="song-item">
+                  <div className="song-info">
+                    <p className="song-title">{song.title} - {song.artist}</p>
+                    <p className="song-text">Genre: {song.genre} | Requested by: {song.firstName} {song.lastName}</p>
+                  </div>
+                  <div className="song-actions">
+                    <button
+                      className="song-manager-button find-button"
+                      onClick={() => {
+                        const token = validateToken();
+                        if (token) handleYoutubeSearch(song.id, song.title, song.artist, token);
+                      }}
+                      onTouchStart={() => {
+                        const token = validateToken();
+                        if (token) handleYoutubeSearch(song.id, song.title, song.artist, token);
+                      }}
+                    >
+                      Find Karaoke
+                    </button>
+                    <button
+                      className="song-manager-button manual-button"
+                      onClick={() => toggleManualInput(song.id)}
+                      onTouchStart={() => toggleManualInput(song.id)}
+                    >
+                      Manual Link
+                    </button>
+                    <button
+                      className="song-manager-button reject-button"
+                      onClick={() => {
+                        const token = validateToken();
+                        if (token) handleRejectSong(song.id, token);
+                      }}
+                      onTouchStart={() => {
+                        const token = validateToken();
+                        if (token) handleRejectSong(song.id, token);
+                      }}
+                    >
+                      Reject
+                    </button>
+                  </div>
+                  {showManualInput[song.id] && (
+                    <div className="manual-link-input">
+                      <input
+                        type="text"
+                        value={manualLinks[song.id] || ""}
+                        onChange={(e) => handleManualLinkChange(song.id, e.target.value)}
+                        placeholder="Enter YouTube URL"
+                        className="song-manager-input"
+                      />
+                      <button
+                        className="song-manager-button approve-button"
+                        onClick={() => {
+                          const token = validateToken();
+                          if (token) handleApproveSong(song.id, manualLinks[song.id] || "", token);
+                        }}
+                        onTouchStart={() => {
+                          const token = validateToken();
+                          if (token) handleApproveSong(song.id, manualLinks[song.id] || "", token);
+                        }}
+                      >
+                        Submit Manual Link
+                      </button>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="song-manager-text">No pending songs to review.</p>
+          )}
+        </section>
+      </div>
+
+      {showYoutubeModal && selectedSongId && (
+        <div className="modal-overlay pending-song-manager">
+          <div className="modal-content youtube-modal">
+            <h2 className="modal-title">Select Karaoke Video for {pendingSongs.find(s => s.id === selectedSongId)?.title}</h2>
+            <div className="youtube-modal-content">
+              <div className="youtube-list">
+                {youtubeError ? (
+                  <p className="error-text">{youtubeError}</p>
+                ) : youtubeResults.length > 0 ? (
+                  <ul className="youtube-results">
+                    {youtubeResults.map(video => (
+                      <li key={video.videoId} className="youtube-item">
+                        <div className="youtube-info">
+                          <p className="youtube-title">{video.title}</p>
+                          <p className="youtube-meta">Channel: {video.channelTitle}</p>
+                          <p className="youtube-meta">Duration: {formatDuration(video.duration)}</p>
+                          <p className="youtube-meta">Uploaded: {formatDate(video.uploadDate)}</p>
+                          <p className="youtube-meta">Views: {formatViewCount(video.viewCount)}</p>
+                        </div>
+                        <div className="youtube-actions">
+                          <button
+                            className="song-manager-button preview-button"
+                            onClick={() => handlePreviewVideo(video.videoId, video.url)}
+                            onTouchStart={() => handlePreviewVideo(video.videoId, video.url)}
+                          >
+                            Preview
+                          </button>
+                          <button
+                            className="song-manager-button approve-button"
+                            onClick={() => {
+                              const token = validateToken();
+                              if (token) handleApproveSong(selectedSongId, video.url, token);
+                            }}
+                            onTouchStart={() => {
+                              const token = validateToken();
+                              if (token) handleApproveSong(selectedSongId, video.url, token);
+                            }}
+                          >
+                            Accept
+                          </button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="song-text">No karaoke videos found.</p>
+                )}
+              </div>
+              <div className="youtube-preview">
+                {selectedVideo ? (
+                  isVideoEmbeddable ? (
+                    <iframe
+                      width="300"
+                      height="169"
+                      src={`https://www.youtube.com/embed/${selectedVideo.videoId}`}
+                      title="YouTube Preview"
+                      frameBorder="0"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                      onError={handleIframeError}
+                    />
+                  ) : (
+                    <div className="youtube-fallback">
+                      <p>Video not embeddable, please watch on YouTube.</p>
+                      <a
+                        href={selectedVideo.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="watch-link"
+                      >
+                        Watch on YouTube
+                      </a>
+                    </div>
+                  )
+                ) : (
+                  <p className="song-text">Select a video to preview.</p>
+                )}
+              </div>
+            </div>
+            <div className="modal-buttons">
+              <button
+                className="song-manager-button close-button"
+                onClick={() => setShowYoutubeModal(false)}
+                onTouchStart={() => setShowYoutubeModal(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PendingSongManagerPage;
+

--- a/bnkaraoke.web/src/pages/SongManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/SongManagerPage.tsx
@@ -4,18 +4,6 @@ import { useNavigate } from "react-router-dom";
 import { API_ROUTES } from "../config/apiConfig";
 import "./SongManagerPage.css";
 
-interface PendingSong {
-  id: number;
-  title: string;
-  artist: string;
-  genre: string;
-  status: string;
-  requestDate: string;
-  spotifyId: string | null;
-  firstName: string;
-  lastName: string;
-}
-
 interface SongUpdate {
   Id: number;
   Title: string;
@@ -35,39 +23,10 @@ interface SongUpdate {
   Valence: number | null;
 }
 
-interface YouTubeVideo {
-  videoId: string;
-  title: string;
-  url: string;
-  channelTitle: string;
-  duration: string;
-  uploadDate: string;
-  viewCount: number;
-}
-
-interface KaraokeChannel {
-  Id: number;
-  ChannelName: string;
-  ChannelId: string | null;
-  SortOrder: number;
-  IsActive: boolean;
-}
-
 const SongManagerPage: React.FC = () => {
-  console.log("SongManagerPage component initializing");
   const navigate = useNavigate();
-  const [pendingSongs, setPendingSongs] = useState<PendingSong[]>([]);
   const [manageableSongs, setManageableSongs] = useState<SongUpdate[]>([]);
-  const [youtubeResults, setYoutubeResults] = useState<YouTubeVideo[]>([]);
-  const [selectedSongId, setSelectedSongId] = useState<number | null>(null);
-  const [manualLinks, setManualLinks] = useState<{ [key: number]: string }>({});
-  const [showManualInput, setShowManualInput] = useState<{ [key: number]: boolean }>({});
-  const [selectedVideo, setSelectedVideo] = useState<{ videoId: string; url: string } | null>(null);
-  const [isVideoEmbeddable, setIsVideoEmbeddable] = useState<boolean>(true);
-  const [showYoutubeModal, setShowYoutubeModal] = useState(false);
-  const [karaokeChannels, setKaraokeChannels] = useState<KaraokeChannel[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [youtubeError, setYoutubeError] = useState<string | null>(null);
   const [editSong, setEditSong] = useState<SongUpdate | null>(null);
   const [filterQuery, setFilterQuery] = useState("");
   const [filterArtist, setFilterArtist] = useState("");
@@ -77,15 +36,13 @@ const SongManagerPage: React.FC = () => {
     const token = localStorage.getItem("token");
     const userName = localStorage.getItem("userName");
     if (!token || !userName) {
-      console.error("[SONG_MANAGER] No token or userName found");
       setError("Authentication token or username missing. Please log in again.");
       navigate("/login");
       return null;
     }
 
     try {
-      if (token.split('.').length !== 3) {
-        console.error("[SONG_MANAGER] Malformed token: does not contain three parts");
+      if (token.split(".").length !== 3) {
         localStorage.removeItem("token");
         localStorage.removeItem("userName");
         setError("Invalid token format. Please log in again.");
@@ -93,20 +50,17 @@ const SongManagerPage: React.FC = () => {
         return null;
       }
 
-      const payload = JSON.parse(atob(token.split('.')[1]));
+      const payload = JSON.parse(atob(token.split(".")[1]));
       const exp = payload.exp * 1000;
       if (exp < Date.now()) {
-        console.error("[SONG_MANAGER] Token expired:", new Date(exp).toISOString());
         localStorage.removeItem("token");
         localStorage.removeItem("userName");
         setError("Session expired. Please log in again.");
         navigate("/login");
         return null;
       }
-      console.log("[SONG_MANAGER] Token validated:", { userName, exp: new Date(exp).toISOString() });
       return token;
     } catch (err) {
-      console.error("[SONG_MANAGER] Token validation error:", err);
       localStorage.removeItem("token");
       localStorage.removeItem("userName");
       setError("Invalid token. Please log in again.");
@@ -115,280 +69,57 @@ const SongManagerPage: React.FC = () => {
     }
   };
 
-  const fetchKaraokeChannels = useCallback(async (token: string) => {
-    try {
-      console.log(`Fetching karaoke channels from: ${API_ROUTES.KARAOKE_CHANNELS}`);
-      const response = await fetch(API_ROUTES.KARAOKE_CHANNELS, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!response.ok) {
-        throw new Error(`Failed to fetch karaoke channels: ${response.status} ${response.statusText}`);
+  const fetchManageableSongs = useCallback(
+    async (token: string) => {
+      try {
+        const queryParams = new URLSearchParams({
+          query: filterQuery,
+          artist: filterArtist,
+          status: filterStatus,
+          page: "1",
+          pageSize: "50",
+        }).toString();
+        const response = await fetch(`${API_ROUTES.SONGS_MANAGE}?${queryParams}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        const text = await response.text();
+        if (!response.ok) {
+          throw new Error(`Failed to fetch manageable songs: ${response.status} ${response.statusText} - ${text}`);
+        }
+        const data = JSON.parse(text);
+        setManageableSongs(data.songs || []);
+        setError(null);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        setError(message);
+        setManageableSongs([]);
       }
-      const data: KaraokeChannel[] = await response.json();
-      console.log("Karaoke Channels fetched:", data);
-      setKaraokeChannels(data);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown error";
-      console.error("Fetch Karaoke Channels Error:", errorMessage, err);
-      setKaraokeChannels([]);
-      setError(errorMessage);
-    }
-  }, []);
-
-  const fetchPendingSongs = useCallback(async (token: string) => {
-    try {
-      console.log(`Fetching pending songs from: ${API_ROUTES.PENDING_SONGS}`);
-      const response = await fetch(API_ROUTES.PENDING_SONGS, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const responseText = await response.text();
-      console.log("Pending Songs Raw Response:", responseText);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch pending songs: ${response.status} ${response.statusText} - ${responseText}`);
-      }
-      const data: PendingSong[] = JSON.parse(responseText);
-      console.log("Pending Songs Parsed:", data);
-      // Verify key uniqueness
-      const idSet = new Set(data.map(song => song.id));
-      if (idSet.size !== data.length) {
-        console.warn("Duplicate song IDs detected:", data.map(song => song.id));
-      }
-      setPendingSongs(data);
-      setError(null);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? `${err.message} (Network error: ${err.cause ? err.cause : 'Unknown'})` : "Unknown fetch error";
-      setError(errorMessage);
-      setPendingSongs([]);
-      console.error("Fetch Pending Songs Error:", errorMessage, err);
-    }
-  }, []);
-
-  const fetchManageableSongs = useCallback(async (token: string) => {
-    try {
-      console.log(`Fetching manageable songs from: ${API_ROUTES.SONGS_MANAGE}`);
-      const queryParams = new URLSearchParams({
-        query: filterQuery,
-        artist: filterArtist,
-        status: filterStatus,
-        page: "1",
-        pageSize: "50",
-      }).toString();
-      const response = await fetch(`${API_ROUTES.SONGS_MANAGE}?${queryParams}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const responseText = await response.text();
-      console.log("Manageable Songs Raw Response:", responseText);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch manageable songs: ${response.status} ${response.statusText} - ${responseText}`);
-      }
-      const data = JSON.parse(responseText);
-      const songs = data.songs || [];
-      console.log("Manageable Songs Parsed:", songs);
-      // Verify key uniqueness
-      const idSet = new Set(songs.map((song: SongUpdate) => song.Id));
-      if (idSet.size !== songs.length) {
-        console.warn("Duplicate song IDs detected:", songs.map((song: SongUpdate) => song.Id));
-      }
-      setManageableSongs(songs);
-      setError(null);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown fetch error";
-      setError(errorMessage);
-      setManageableSongs([]);
-      console.error("Fetch Manageable Songs Error:", errorMessage, err);
-    }
-  }, [filterQuery, filterArtist, filterStatus]);
+    },
+    [filterQuery, filterArtist, filterStatus]
+  );
 
   useEffect(() => {
-    try {
-      console.log("SongManagerPage useEffect running");
-      const token = validateToken();
-      if (!token) return;
+    const token = validateToken();
+    if (!token) return;
 
-      const storedRoles = localStorage.getItem("roles");
-      if (storedRoles) {
-        const parsedRoles = JSON.parse(storedRoles);
-        if (!parsedRoles.includes("Song Manager")) {
-          console.log("User lacks Song Manager role, redirecting to dashboard");
-          navigate("/dashboard");
-          return;
-        }
-      } else {
-        console.log("No roles found, redirecting to login");
-        navigate("/login");
+    const storedRoles = localStorage.getItem("roles");
+    if (storedRoles) {
+      const parsedRoles = JSON.parse(storedRoles);
+      if (!parsedRoles.includes("Song Manager")) {
+        navigate("/dashboard");
         return;
       }
-      fetchPendingSongs(token);
-      fetchManageableSongs(token);
-      fetchKaraokeChannels(token);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown error";
-      console.error("SongManagerPage useEffect error:", errorMessage, err);
-      setError(errorMessage);
+    } else {
+      navigate("/login");
+      return;
     }
-  }, [navigate, fetchPendingSongs, fetchManageableSongs, fetchKaraokeChannels]);
 
-  const handleYoutubeSearch = async (songId: number, title: string, artist: string, token: string) => {
-    try {
-      const query = `Karaoke ${title} ${artist}`;
-      console.log(`Fetching YouTube search for song ${songId} from: ${API_ROUTES.YOUTUBE_SEARCH}`);
-      const response = await fetch(`${API_ROUTES.YOUTUBE_SEARCH}?query=${encodeURIComponent(query)}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      const responseText = await response.text();
-      console.log(`YouTube Search Raw Response for Song ${songId}:`, responseText);
-      if (!response.ok) {
-        throw new Error(`Failed to search YouTube: ${response.status} ${response.statusText} - ${responseText}`);
-      }
-      const data: YouTubeVideo[] = JSON.parse(responseText);
-      // Verify key uniqueness
-      const videoIdSet = new Set(data.map(video => video.videoId));
-      if (videoIdSet.size !== data.length) {
-        console.warn("Duplicate video IDs detected:", data.map(video => video.videoId));
-      }
-      const sortedResults = data.sort((a, b) => {
-        const aChannel = karaokeChannels.find(c => c.ChannelName === a.channelTitle);
-        const bChannel = karaokeChannels.find(c => c.ChannelName === b.channelTitle);
-        const aOrder = aChannel ? aChannel.SortOrder : Number.MAX_SAFE_INTEGER;
-        const bOrder = bChannel ? bChannel.SortOrder : Number.MAX_SAFE_INTEGER;
-        return aOrder - bOrder;
-      });
-      console.log(`YouTube Results Parsed for Song ${songId}:`, sortedResults);
-      setYoutubeResults(sortedResults);
-      setSelectedSongId(songId);
-      setSelectedVideo(null);
-      setIsVideoEmbeddable(true);
-      setShowYoutubeModal(true);
-      setYoutubeError(null);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown fetch error";
-      console.error("YouTube Search Error:", errorMessage, err);
-      setYoutubeError(errorMessage);
-      setYoutubeResults([]);
-      setSelectedSongId(songId);
-      setSelectedVideo(null);
-      setIsVideoEmbeddable(true);
-      setShowYoutubeModal(true);
-    }
-  };
-
-  const handlePreviewVideo = (videoId: string, url: string) => {
-    try {
-      console.log("Previewing video:", { videoId, url });
-      setSelectedVideo({ videoId, url });
-      setIsVideoEmbeddable(true);
-    } catch (err: unknown) {
-      console.error("HandlePreviewVideo Error:", err);
-    }
-  };
-
-  const handleIframeError = () => {
-    try {
-      console.log("Iframe error occurred");
-      setIsVideoEmbeddable(false);
-    } catch (err: unknown) {
-      console.error("HandleIframeError Error:", err);
-    }
-  };
-
-  const formatDuration = (isoDuration: string): string => {
-    try {
-      const match = isoDuration.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
-      if (!match) return "0:00";
-      const hours = parseInt(match[1] || "0", 10);
-      const minutes = parseInt(match[2] || "0", 10);
-      const seconds = parseInt(match[3] || "0", 10);
-      if (hours > 0) {
-        return `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
-      }
-      return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-    } catch (err: unknown) {
-      console.error("FormatDuration Error:", err);
-      return "0:00";
-    }
-  };
-
-  const formatDate = (isoDate: string): string => {
-    try {
-      const date = new Date(isoDate);
-      return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    } catch (err: unknown) {
-      console.error("FormatDate Error:", err);
-      return "Unknown";
-    }
-  };
-
-  const formatViewCount = (count: number): string => {
-    try {
-      if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
-      if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
-      return count.toString();
-    } catch (err: unknown) {
-      console.error("FormatViewCount Error:", err);
-      return "0";
-    }
-  };
-
-  const handleApproveSong = async (songId: number, YouTubeUrl: string, token: string) => {
-    try {
-      console.log(`Approving song ${songId} at: ${API_ROUTES.APPROVE_SONGS}`);
-      const response = await fetch(API_ROUTES.APPROVE_SONGS, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ id: songId, YouTubeUrl }),
-      });
-      const responseText = await response.text();
-      console.log(`Approve Song Raw Response for Song ${songId}:`, responseText);
-      if (!response.ok) {
-        throw new Error(`Failed to approve song: ${response.status} ${response.statusText} - ${responseText}`);
-      }
-      alert("Song approved successfully!");
-      fetchPendingSongs(token);
-      fetchManageableSongs(token);
-      setShowManualInput((prev) => ({ ...prev, [songId]: false }));
-      setShowYoutubeModal(false);
-      setYoutubeResults([]);
-      setSelectedVideo(null);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown fetch error";
-      setError(errorMessage);
-      console.error("Approve Song Error:", errorMessage, err);
-    }
-  };
-
-  const handleRejectSong = async (songId: number, token: string) => {
-    try {
-      console.log(`Rejecting song ${songId} at: ${API_ROUTES.REJECT_SONG}`);
-      const response = await fetch(API_ROUTES.REJECT_SONG, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ id: songId }),
-      });
-      const responseText = await response.text();
-      console.log(`Reject Song Raw Response for Song ${songId}:`, responseText);
-      if (!response.ok) {
-        throw new Error(`Failed to reject song: ${response.status} ${response.statusText} - ${responseText}`);
-      }
-      alert("Song rejected successfully!");
-      fetchPendingSongs(token);
-      fetchManageableSongs(token);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown fetch error";
-      setError(errorMessage);
-      console.error("Reject Song Error:", errorMessage, err);
-    }
-  };
+    fetchManageableSongs(token);
+  }, [navigate, fetchManageableSongs]);
 
   const handleEditSong = async (token: string) => {
     if (!editSong) return;
     try {
-      console.log(`Updating song ${editSong.Id} at: ${API_ROUTES.SONG_UPDATE}/${editSong.Id}`);
       const response = await fetch(`${API_ROUTES.SONG_UPDATE}/${editSong.Id}`, {
         method: "PUT",
         headers: {
@@ -404,16 +135,14 @@ const SongManagerPage: React.FC = () => {
       fetchManageableSongs(token);
       setEditSong(null);
       setError(null);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown fetch error";
-      setError(errorMessage);
-      console.error("Update Song Error:", errorMessage, err);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
     }
   };
 
   const handleDeleteSong = async (id: number, token: string) => {
     try {
-      console.log(`Deleting song ${id} at: ${API_ROUTES.SONG_DELETE}/${id}`);
       const response = await fetch(`${API_ROUTES.SONG_DELETE}/${id}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
@@ -423,17 +152,14 @@ const SongManagerPage: React.FC = () => {
       }
       alert("Song deleted successfully!");
       fetchManageableSongs(token);
-      setError(null);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown fetch error";
-      setError(errorMessage);
-      console.error("Delete Song Error:", errorMessage, err);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
     }
   };
 
   const handleClearYouTubeUrl = async (id: number, token: string) => {
     try {
-      console.log(`Clearing YouTube URL for song ${id} at: ${API_ROUTES.SONG_UPDATE}/${id}`);
       const song = manageableSongs.find(s => s.Id === id);
       if (!song) throw new Error("Song not found");
       const updatedSong = { ...song, YouTubeUrl: null };
@@ -450,468 +176,271 @@ const SongManagerPage: React.FC = () => {
       }
       alert("YouTube URL cleared successfully!");
       fetchManageableSongs(token);
-      setError(null);
-    } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown fetch error";
-      setError(errorMessage);
-      console.error("Clear YouTube URL Error:", errorMessage, err);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
     }
   };
 
-  const toggleManualInput = (songId: number) => {
-    try {
-      console.log("Toggling manual input for song:", songId);
-      setShowManualInput((prev) => ({ ...prev, [songId]: !prev[songId] }));
-    } catch (err: unknown) {
-      console.error("ToggleManualInput Error:", err);
-    }
-  };
+  return (
+    <div className="song-manager-container mobile-song-manager">
+      <header className="song-manager-header">
+        <h1 className="song-manager-title">Song Manager</h1>
+        <div className="header-buttons">
+          <button
+            className="song-manager-button channels-button"
+            onClick={() => navigate("/karaoke-channels")}
+            onTouchStart={() => navigate("/karaoke-channels")}
+          >
+            Manage Channels
+          </button>
+          <button
+            className="song-manager-button back-button"
+            onClick={() => navigate("/dashboard")}
+            onTouchStart={() => navigate("/dashboard")}
+          >
+            Back to Dashboard
+          </button>
+        </div>
+      </header>
 
-  const handleManualLinkChange = (songId: number, value: string) => {
-    try {
-      console.log("Updating manual link for song:", songId, value);
-      setManualLinks((prev) => ({ ...prev, [songId]: value }));
-    } catch (err: unknown) {
-      console.error("HandleManualLinkChange Error:", err);
-    }
-  };
-
-  try {
-    console.log("SongManagerPage rendering");
-    return (
-      <div className="song-manager-container mobile-song-manager">
-        <header className="song-manager-header">
-          <h1 className="song-manager-title">Song Manager</h1>
-          <div className="header-buttons">
-            <button 
-              className="song-manager-button channels-button" 
-              onClick={() => navigate("/karaoke-channels")}
-              onTouchStart={() => navigate("/karaoke-channels")}
+      <div className="song-manager-content">
+        <section className="song-editor-card">
+          <h2 className="section-title">Manage Songs</h2>
+          <div className="filter-section">
+            <input
+              type="text"
+              value={filterQuery}
+              onChange={(e) => setFilterQuery(e.target.value)}
+              placeholder="Search by title or artist"
+              className="song-manager-input"
+            />
+            <input
+              type="text"
+              value={filterArtist}
+              onChange={(e) => setFilterArtist(e.target.value)}
+              placeholder="Filter by artist"
+              className="song-manager-input"
+            />
+            <select
+              value={filterStatus}
+              onChange={(e) => setFilterStatus(e.target.value)}
+              className="song-manager-input"
             >
-              Manage Channels
-            </button>
-            <button 
-              className="song-manager-button back-button" 
-              onClick={() => navigate("/dashboard")}
-              onTouchStart={() => navigate("/dashboard")}
+              <option value="">All Statuses</option>
+              <option value="active">Active</option>
+              <option value="pending">Pending</option>
+              <option value="unavailable">Unavailable</option>
+            </select>
+            <button
+              className="song-manager-button filter-button"
+              onClick={() => {
+                const token = validateToken();
+                if (token) fetchManageableSongs(token);
+              }}
+              onTouchStart={() => {
+                const token = validateToken();
+                if (token) fetchManageableSongs(token);
+              }}
             >
-              Back to Dashboard
+              Apply Filters
             </button>
           </div>
-        </header>
+          {error && <p className="error-text">{error}</p>}
+          {manageableSongs.length > 0 ? (
+            <ul className="song-list">
+              {manageableSongs.map(song => (
+                <li key={song.Id} className="song-item">
+                  <div className="song-info">
+                    <p className="song-title">{song.Title} - {song.Artist}</p>
+                    <p className="song-text">Genre: {song.Genre || "Unknown"} | Status: {song.Status}</p>
+                  </div>
+                  <div className="song-actions">
+                    <button
+                      className="song-manager-button edit-button"
+                      onClick={() => setEditSong(song)}
+                      onTouchStart={() => setEditSong(song)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className="song-manager-button clear-url-button"
+                      onClick={() => {
+                        const token = validateToken();
+                        if (token) handleClearYouTubeUrl(song.Id, token);
+                      }}
+                      onTouchStart={() => {
+                        const token = validateToken();
+                        if (token) handleClearYouTubeUrl(song.Id, token);
+                      }}
+                    >
+                      Clear YouTube URL
+                    </button>
+                    <button
+                      className="song-manager-button delete-button"
+                      onClick={() => {
+                        const token = validateToken();
+                        if (token) handleDeleteSong(song.Id, token);
+                      }}
+                      onTouchStart={() => {
+                        const token = validateToken();
+                        if (token) handleDeleteSong(song.Id, token);
+                      }}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="song-manager-text">No songs match the filters.</p>
+          )}
+        </section>
+      </div>
 
-        <div className="song-manager-content">
-          <div className="song-manager-sections">
-            <section className="song-manager-card">
-              <h2 className="section-title">Pending Songs</h2>
-              {error && <p className="error-text">{error}</p>}
-              {pendingSongs.length > 0 ? (
-                <ul className="song-list">
-                  {pendingSongs.map((song, index) => (
-                    <li key={song.id || `pending-${index}`} className="song-item">
-                      <div className="song-info">
-                        <p className="song-title">{song.title} - {song.artist}</p>
-                        <p className="song-text">Genre: {song.genre} | Requested by: {song.firstName} {song.lastName}</p>
-                      </div>
-                      <div className="song-actions">
-                        <button
-                          className="song-manager-button find-button"
-                          onClick={() => {
-                            const token = validateToken();
-                            if (token) handleYoutubeSearch(song.id, song.title, song.artist, token);
-                          }}
-                          onTouchStart={() => {
-                            const token = validateToken();
-                            if (token) handleYoutubeSearch(song.id, song.title, song.artist, token);
-                          }}
-                        >
-                          Find Karaoke Video
-                        </button>
-                        <button
-                          className="song-manager-button manual-button"
-                          onClick={() => toggleManualInput(song.id)}
-                          onTouchStart={() => toggleManualInput(song.id)}
-                        >
-                          Add Manual Link
-                        </button>
-                        <button
-                          className="song-manager-button reject-button"
-                          onClick={() => {
-                            const token = validateToken();
-                            if (token) handleRejectSong(song.id, token);
-                          }}
-                          onTouchStart={() => {
-                            const token = validateToken();
-                            if (token) handleRejectSong(song.id, token);
-                          }}
-                        >
-                          Reject
-                        </button>
-                      </div>
-                      {showManualInput[song.id] && (
-                        <div className="manual-link-input">
-                          <input
-                            type="text"
-                            value={manualLinks[song.id] || ""}
-                            onChange={(e) => handleManualLinkChange(song.id, e.target.value)}
-                            placeholder="Enter YouTube URL"
-                            className="song-manager-input"
-                          />
-                          <button
-                            className="song-manager-button approve-button"
-                            onClick={() => {
-                              const token = validateToken();
-                              if (token) handleApproveSong(song.id, manualLinks[song.id] || "", token);
-                            }}
-                            onTouchStart={() => {
-                              const token = validateToken();
-                              if (token) handleApproveSong(song.id, manualLinks[song.id] || "", token);
-                            }}
-                          >
-                            Submit Manual Link
-                          </button>
-                        </div>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="song-manager-text">No pending songs to review.</p>
-              )}
-            </section>
-
-            <section className="song-editor-card">
-              <h2 className="section-title">Manage Songs</h2>
-              <div className="filter-section">
-                <input
-                  type="text"
-                  value={filterQuery}
-                  onChange={(e) => setFilterQuery(e.target.value)}
-                  placeholder="Search by title or artist"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={filterArtist}
-                  onChange={(e) => setFilterArtist(e.target.value)}
-                  placeholder="Filter by artist"
-                  className="song-manager-input"
-                />
-                <select
-                  value={filterStatus}
-                  onChange={(e) => setFilterStatus(e.target.value)}
-                  className="song-manager-input"
-                >
-                  <option value="">All Statuses</option>
-                  <option value="active">Active</option>
-                  <option value="pending">Pending</option>
-                  <option value="unavailable">Unavailable</option>
-                </select>
-                <button
-                  className="song-manager-button filter-button"
-                  onClick={() => {
-                    const token = validateToken();
-                    if (token) fetchManageableSongs(token);
-                  }}
-                  onTouchStart={() => {
-                    const token = validateToken();
-                    if (token) fetchManageableSongs(token);
-                  }}
-                >
-                  Apply Filters
-                </button>
-              </div>
-              {error && <p className="error-text">{error}</p>}
-              {manageableSongs.length > 0 ? (
-                <ul className="song-list">
-                  {manageableSongs.map((song, index) => (
-                    <li key={song.Id || `manageable-${index}`} className="song-item">
-                      <div className="song-info">
-                        <p className="song-title">{song.Title} - {song.Artist}</p>
-                        <p className="song-text">Genre: {song.Genre || "Unknown"} | Status: {song.Status}</p>
-                      </div>
-                      <div className="song-actions">
-                        <button
-                          className="song-manager-button edit-button"
-                          onClick={() => setEditSong(song)}
-                          onTouchStart={() => setEditSong(song)}
-                        >
-                          Edit
-                        </button>
-                        <button
-                          className="song-manager-button clear-url-button"
-                          onClick={() => {
-                            const token = validateToken();
-                            if (token) handleClearYouTubeUrl(song.Id, token);
-                          }}
-                          onTouchStart={() => {
-                            const token = validateToken();
-                            if (token) handleClearYouTubeUrl(song.Id, token);
-                          }}
-                        >
-                          Clear YouTube URL
-                        </button>
-                        <button
-                          className="song-manager-button delete-button"
-                          onClick={() => {
-                            const token = validateToken();
-                            if (token) handleDeleteSong(song.Id, token);
-                          }}
-                          onTouchStart={() => {
-                            const token = validateToken();
-                            if (token) handleDeleteSong(song.Id, token);
-                          }}
-                        >
-                          Delete
-                        </button>
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="song-manager-text">No songs match the filters.</p>
-              )}
-            </section>
+      {editSong && (
+        <div className="modal-overlay mobile-song-manager">
+          <div className="modal-content">
+            <h2 className="modal-title">Edit Song</h2>
+            <div className="edit-form">
+              <input
+                type="text"
+                value={editSong.Title || ""}
+                onChange={(e) => setEditSong({ ...editSong, Title: e.target.value })}
+                placeholder="Title"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.Artist || ""}
+                onChange={(e) => setEditSong({ ...editSong, Artist: e.target.value })}
+                placeholder="Artist"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.Genre || ""}
+                onChange={(e) => setEditSong({ ...editSong, Genre: e.target.value })}
+                placeholder="Genre"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.Decade || ""}
+                onChange={(e) => setEditSong({ ...editSong, Decade: e.target.value })}
+                placeholder="Decade (e.g., 1980s)"
+                className="song-manager-input"
+              />
+              <input
+                type="number"
+                step="0.1"
+                value={editSong.Bpm || ""}
+                onChange={(e) => setEditSong({ ...editSong, Bpm: parseFloat(e.target.value) || null })}
+                placeholder="BPM"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.Danceability || ""}
+                onChange={(e) => setEditSong({ ...editSong, Danceability: e.target.value })}
+                placeholder="Danceability (e.g., danceable)"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.Energy || ""}
+                onChange={(e) => setEditSong({ ...editSong, Energy: e.target.value })}
+                placeholder="Energy (e.g., aggressive)"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.Mood || ""}
+                onChange={(e) => setEditSong({ ...editSong, Mood: e.target.value })}
+                placeholder="Mood (e.g., happy)"
+                className="song-manager-input"
+              />
+              <input
+                type="number"
+                value={editSong.Popularity || ""}
+                onChange={(e) => setEditSong({ ...editSong, Popularity: parseInt(e.target.value) || null })}
+                placeholder="Popularity"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.SpotifyId || ""}
+                onChange={(e) => setEditSong({ ...editSong, SpotifyId: e.target.value })}
+                placeholder="Spotify ID"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.YouTubeUrl || ""}
+                onChange={(e) => setEditSong({ ...editSong, YouTubeUrl: e.target.value })}
+                placeholder="YouTube URL"
+                className="song-manager-input"
+              />
+              <input
+                type="text"
+                value={editSong.MusicBrainzId || ""}
+                onChange={(e) => setEditSong({ ...editSong, MusicBrainzId: e.target.value })}
+                placeholder="MusicBrainz ID"
+                className="song-manager-input"
+              />
+              <input
+                type="number"
+                value={editSong.LastFmPlaycount || ""}
+                onChange={(e) => setEditSong({ ...editSong, LastFmPlaycount: parseInt(e.target.value) || null })}
+                placeholder="Last.fm Playcount"
+                className="song-manager-input"
+              />
+              <input
+                type="number"
+                value={editSong.Valence || ""}
+                onChange={(e) => setEditSong({ ...editSong, Valence: parseInt(e.target.value) || null })}
+                placeholder="Valence"
+                className="song-manager-input"
+              />
+              <select
+                value={editSong.Status || ""}
+                onChange={(e) => setEditSong({ ...editSong, Status: e.target.value })}
+                className="song-manager-input"
+              >
+                <option value="active">Active</option>
+                <option value="pending">Pending</option>
+                <option value="unavailable">Unavailable</option>
+              </select>
+            </div>
+            <div className="modal-buttons">
+              <button
+                className="song-manager-button save-button"
+                onClick={() => {
+                  const token = validateToken();
+                  if (token) handleEditSong(token);
+                }}
+                onTouchStart={() => {
+                  const token = validateToken();
+                  if (token) handleEditSong(token);
+                }}
+              >
+                Save
+              </button>
+              <button
+                className="song-manager-button close-button"
+                onClick={() => setEditSong(null)}
+                onTouchStart={() => setEditSong(null)}
+              >
+                Cancel
+              </button>
+            </div>
           </div>
         </div>
-
-        {showYoutubeModal && selectedSongId && (
-          <div className="modal-overlay mobile-song-manager">
-            <div className="modal-content youtube-modal">
-              <h2 className="modal-title">Select Karaoke Video for {pendingSongs.find(s => s.id === selectedSongId)?.title}</h2>
-              <div className="youtube-modal-content">
-                <div className="youtube-list">
-                  {youtubeError ? (
-                    <p className="error-text">{youtubeError}</p>
-                  ) : youtubeResults.length > 0 ? (
-                    <ul className="youtube-results">
-                      {youtubeResults.map((video, index) => (
-                        <li key={video.videoId || `youtube-${index}`} className="youtube-item">
-                          <div className="youtube-info">
-                            <p className="youtube-title">{video.title}</p>
-                            <p className="youtube-meta">Channel: {video.channelTitle}</p>
-                            <p className="youtube-meta">Duration: {formatDuration(video.duration)}</p>
-                            <p className="youtube-meta">Uploaded: {formatDate(video.uploadDate)}</p>
-                            <p className="youtube-meta">Views: {formatViewCount(video.viewCount)}</p>
-                          </div>
-                          <div className="youtube-actions">
-                            <button
-                              className="song-manager-button preview-button"
-                              onClick={() => handlePreviewVideo(video.videoId, video.url)}
-                              onTouchStart={() => handlePreviewVideo(video.videoId, video.url)}
-                            >
-                              Preview
-                            </button>
-                            <button
-                              className="song-manager-button approve-button"
-                              onClick={() => {
-                                const token = validateToken();
-                                if (token) handleApproveSong(selectedSongId, video.url, token);
-                              }}
-                              onTouchStart={() => {
-                                const token = validateToken();
-                                if (token) handleApproveSong(selectedSongId, video.url, token);
-                              }}
-                            >
-                              Accept
-                            </button>
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : (
-                    <p className="song-text">No karaoke videos found.</p>
-                  )}
-                </div>
-                <div className="youtube-preview">
-                  {selectedVideo ? (
-                    isVideoEmbeddable ? (
-                      <iframe
-                        width="300"
-                        height="169"
-                        src={`https://www.youtube.com/embed/${selectedVideo.videoId}`}
-                        title="YouTube Preview"
-                        frameBorder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowFullScreen
-                        onError={handleIframeError}
-                      />
-                    ) : (
-                      <div className="youtube-fallback">
-                        <p>Video not embeddable, please watch on YouTube.</p>
-                        <a
-                          href={selectedVideo.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="watch-link"
-                        >
-                          Watch on YouTube
-                        </a>
-                      </div>
-                    )
-                  ) : (
-                    <p className="song-text">Select a video to preview.</p>
-                  )}
-                </div>
-              </div>
-              <div className="modal-buttons">
-                <button 
-                  className="song-manager-button close-button" 
-                  onClick={() => setShowYoutubeModal(false)}
-                  onTouchStart={() => setShowYoutubeModal(false)}
-                >
-                  Close
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {editSong && (
-          <div className="modal-overlay mobile-song-manager">
-            <div className="modal-content">
-              <h2 className="modal-title">Edit Song</h2>
-              <div className="edit-form">
-                <input
-                  type="text"
-                  value={editSong.Title || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Title: e.target.value })}
-                  placeholder="Title"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.Artist || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Artist: e.target.value })}
-                  placeholder="Artist"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.Genre || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Genre: e.target.value })}
-                  placeholder="Genre"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.Decade || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Decade: e.target.value })}
-                  placeholder="Decade (e.g., 1980s)"
-                  className="song-manager-input"
-                />
-                <input
-                  type="number"
-                  step="0.1"
-                  value={editSong.Bpm || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Bpm: parseFloat(e.target.value) || null })}
-                  placeholder="BPM"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.Danceability || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Danceability: e.target.value })}
-                  placeholder="Danceability (e.g., danceable)"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.Energy || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Energy: e.target.value })}
-                  placeholder="Energy (e.g., aggressive)"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.Mood || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Mood: e.target.value })}
-                  placeholder="Mood (e.g., happy)"
-                  className="song-manager-input"
-                />
-                <input
-                  type="number"
-                  value={editSong.Popularity || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Popularity: parseInt(e.target.value) || null })}
-                  placeholder="Popularity"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.SpotifyId || ""}
-                  onChange={(e) => setEditSong({ ...editSong, SpotifyId: e.target.value })}
-                  placeholder="Spotify ID"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.YouTubeUrl || ""}
-                  onChange={(e) => setEditSong({ ...editSong, YouTubeUrl: e.target.value })}
-                  placeholder="YouTube URL"
-                  className="song-manager-input"
-                />
-                <input
-                  type="text"
-                  value={editSong.MusicBrainzId || ""}
-                  onChange={(e) => setEditSong({ ...editSong, MusicBrainzId: e.target.value })}
-                  placeholder="MusicBrainz ID"
-                  className="song-manager-input"
-                />
-                <input
-                  type="number"
-                  value={editSong.LastFmPlaycount || ""}
-                  onChange={(e) => setEditSong({ ...editSong, LastFmPlaycount: parseInt(e.target.value) || null })}
-                  placeholder="Last.fm Playcount"
-                  className="song-manager-input"
-                />
-                <input
-                  type="number"
-                  value={editSong.Valence || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Valence: parseInt(e.target.value) || null })}
-                  placeholder="Valence"
-                  className="song-manager-input"
-                />
-                <select
-                  value={editSong.Status || ""}
-                  onChange={(e) => setEditSong({ ...editSong, Status: e.target.value })}
-                  className="song-manager-input"
-                >
-                  <option value="active">Active</option>
-                  <option value="pending">Pending</option>
-                  <option value="unavailable">Unavailable</option>
-                </select>
-              </div>
-              <div className="modal-buttons">
-                <button
-                  className="song-manager-button save-button"
-                  onClick={() => {
-                    const token = validateToken();
-                    if (token) handleEditSong(token);
-                  }}
-                  onTouchStart={() => {
-                    const token = validateToken();
-                    if (token) handleEditSong(token);
-                  }}
-                >
-                  Save
-                </button>
-                <button
-                  className="song-manager-button close-button"
-                  onClick={() => setEditSong(null)}
-                  onTouchStart={() => setEditSong(null)}
-                >
-                  Cancel
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-      </div>
-    );
-  } catch (error: unknown) {
-    console.error("SongManagerPage render error:", error);
-    return <div>Error in SongManagerPage: {error instanceof Error ? error.message : 'Unknown error'}</div>;
-  }
+      )}
+    </div>
+  );
 };
 
 export default SongManagerPage;
+


### PR DESCRIPTION
## Summary
- refactor song manager to handle only existing songs
- add dedicated pending song manager page with enlarged UI
- expose new page via navigation and routing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b128c1a8d483239b333c782c9df920