### PR TITLE
Allow application managers to review pending songs

### DIFF
--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -62,6 +62,7 @@ const Header: React.FC = memo(() => {
   const hasAdminRole = roles.some((role) => adminRoles.includes(role));
   const adminRoutes = useMemo(() => [
     "/admin/add-requests",
+    "/pending-song-manager",
     "/song-manager",
     "/user-management",
     "/event-management",

--- a/bnkaraoke.web/src/context/EventContext.tsx
+++ b/bnkaraoke.web/src/context/EventContext.tsx
@@ -153,11 +153,11 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
   const checkAttendanceStatus = useCallback(async (event: Event) => {
     const token = validateToken();
     if (!token) return { isCheckedIn: false, isOnBreak: false };
-      const isRestrictedPage = location.pathname.startsWith('/admin') || [
-        '/song-manager', '/user-management', '/event-management',
-        '/explore-songs', '/profile', '/request-song', '/spotify-search',
-        '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
-      ].includes(location.pathname);
+        const isRestrictedPage = location.pathname.startsWith('/admin') || [
+          '/song-manager', '/pending-song-manager', '/user-management', '/event-management',
+          '/explore-songs', '/profile', '/request-song', '/spotify-search',
+          '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
+        ].includes(location.pathname);
     console.log("[EVENT_CONTEXT] Checking attendance status:", { eventId: event.eventId, isRestrictedPage });
     try {
       console.log(`[EVENT_CONTEXT] Fetching attendance status for event ${event.eventId}`);
@@ -240,11 +240,11 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
       console.log("[EVENT_CONTEXT] Live events:", live);
       console.log("[EVENT_CONTEXT] Upcoming events:", upcoming);
 
-      const isRestrictedPage = location.pathname.startsWith('/admin') || [
-        '/song-manager', '/user-management', '/event-management',
-        '/explore-songs', '/profile', '/request-song', '/spotify-search',
-        '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
-      ].includes(location.pathname);
+        const isRestrictedPage = location.pathname.startsWith('/admin') || [
+          '/song-manager', '/pending-song-manager', '/user-management', '/event-management',
+          '/explore-songs', '/profile', '/request-song', '/spotify-search',
+          '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
+        ].includes(location.pathname);
       if (isRestrictedPage) {
         console.log("[EVENT_CONTEXT] Skipping auto-check-in on restricted page:", location.pathname);
         return;
@@ -330,11 +330,11 @@ export const EventContextProvider: React.FC<{ children: ReactNode }> = ({ childr
         setIsOnBreak(false);
         return;
       }
-      const isRestrictedPage = location.pathname.startsWith('/admin') || [
-        '/song-manager', '/user-management', '/event-management',
-        '/explore-songs', '/profile', '/request-song', '/spotify-search',
-        '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
-      ].includes(location.pathname);
+        const isRestrictedPage = location.pathname.startsWith('/admin') || [
+          '/song-manager', '/pending-song-manager', '/user-management', '/event-management',
+          '/explore-songs', '/profile', '/request-song', '/spotify-search',
+          '/karaoke-channels', '/pending-requests', '/add-requests', '/api-maintenance'
+        ].includes(location.pathname);
       if (isRestrictedPage) {
         console.log("[EVENT_CONTEXT] Skipping fetchAttendanceStatus on restricted page:", location.pathname);
         return;

--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
@@ -126,7 +126,9 @@ const PendingSongManagerPage: React.FC = () => {
     const storedRoles = localStorage.getItem("roles");
     if (storedRoles) {
       const parsedRoles = JSON.parse(storedRoles);
-      if (!parsedRoles.includes("Song Manager")) {
+      const allowedRoles = ["Song Manager", "Application Manager"];
+      const hasAccess = parsedRoles.some((role: string) => allowedRoles.includes(role));
+      if (!hasAccess) {
         navigate("/dashboard");
         return;
       }


### PR DESCRIPTION
## Summary
- permit Application Manager role to access the Pending Song Manager page
- treat Pending Song Manager as an admin route in the header and event context

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b1ce4648088323a70f30e72e323b72