### PR TITLE
Fix pending song list title styling

### DIFF
--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.css
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.css
@@ -514,3 +514,17 @@
   width: 600px;
   height: 338px;
 }
+
+/* Ensure pending song titles and details match YouTube result styling */
+.pending-song-manager .song-title {
+  font-size: 1.5rem;
+  color: #22d3ee;
+  text-shadow: none;
+  font-weight: normal;
+}
+
+.pending-song-manager .song-text {
+  font-size: 0.8rem;
+  color: #cccccc;
+  margin: 3px 0 0;
+}


### PR DESCRIPTION
## Summary
- Ensure pending song titles and details use the same styling as YouTube search results

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dbc0d9a883238f05bf8931579d2b