### PR TITLE
Use bright magenta for pending song titles

### DIFF
--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.css
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.css
@@ -110,7 +110,7 @@
 .song-title {
   font-size: 1.5rem;
   margin: 0;
-  color: #22d3ee;
+  color: #ff00ff;
   text-shadow: none;
 }
 


### PR DESCRIPTION
## Summary
- Change pending song title text to bright magenta in Pending Song Manager

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1dd91bee08323a60a39bce8a144de