### PR TITLE
fix: set pending song title color to magenta

### DIFF
--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.css
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.css
@@ -518,7 +518,7 @@
 /* Ensure pending song titles and details match YouTube result styling */
 .pending-song-manager .song-title {
   font-size: 1.5rem;
-  color: #22d3ee;
+  color: #ff00ff;
   text-shadow: none;
   font-weight: normal;
 }


### PR DESCRIPTION
## Summary
- adjust PendingSongManagerPage song titles to bright magenta

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b1f1850bb0832391c16d2247b0d6ec