### PR TITLE
Scope pending song title styling

### DIFF
--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.css
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.css
@@ -107,14 +107,14 @@
   flex: 1;
 }
 
-.song-title {
+.pending-song-manager .song-title {
   font-size: 1.5rem;
   margin: 0;
   color: #ff00ff;
   text-shadow: none;
 }
 
-.song-text {
+.pending-song-manager .song-text {
   font-size: 0.8rem;
   color: #cccccc;
   margin: 3px 0 0;
@@ -324,10 +324,6 @@
   margin: 10px 0;
 }
 
-.song-text {
-  font-size: 0.8rem;
-  color: #cccccc;
-}
 
 /* Tablet (max-width: 991px) */
 @media (max-width: 991px) {
@@ -364,10 +360,10 @@
   .song-item {
     padding: 10px;
   }
-  .song-title {
+  .pending-song-manager .song-title {
     font-size: 1.4rem;
   }
-  .song-text {
+  .pending-song-manager .song-text {
     font-size: 0.8rem;
   }
   .filter-section {
@@ -444,10 +440,10 @@
     width: 100%;
     justify-content: flex-end;
   }
-  .song-title {
+  .pending-song-manager .song-title {
     font-size: 1.3rem;
   }
-  .song-text {
+  .pending-song-manager .song-text {
     font-size: 0.8rem;
   }
   .filter-section {
@@ -515,16 +511,3 @@
   height: 338px;
 }
 
-/* Ensure pending song titles and details match YouTube result styling */
-.pending-song-manager .song-title {
-  font-size: 1.5rem;
-  color: #ff00ff;
-  text-shadow: none;
-  font-weight: normal;
-}
-
-.pending-song-manager .song-text {
-  font-size: 0.8rem;
-  color: #cccccc;
-  margin: 3px 0 0;
-}


### PR DESCRIPTION
## Summary
- scope song title and details styles under `.pending-song-manager` to ensure magenta color only applies within Pending Song Manager
- update responsive rules to use scoped selectors

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1f3f657308323aee761904f221749