### PR TITLE
fix pending song title override in pending song manager

### DIFF
--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.css
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.css
@@ -110,7 +110,7 @@
 .pending-song-manager .song-title {
   font-size: 1.5rem;
   margin: 0;
-  color: #ff00ff;
+  color: #ff00ff !important;
   text-shadow: none;
 }
 

--- a/bnkaraoke.web/src/pages/SongManagerPage.css
+++ b/bnkaraoke.web/src/pages/SongManagerPage.css
@@ -112,7 +112,7 @@
   flex: 1;
 }
 
-.song-title {
+.mobile-song-manager .song-title {
   font-size: 1.2rem;
   margin: 0;
   color: #22d3ee;
@@ -362,7 +362,7 @@
   .song-item {
     padding: 12px;
   }
-  .song-title {
+  .mobile-song-manager .song-title {
     font-size: 1.1rem;
   }
   .song-text {
@@ -442,7 +442,7 @@
     width: 100%;
     justify-content: flex-end;
   }
-  .song-title {
+  .mobile-song-manager .song-title {
     font-size: 1rem;
   }
   .song-text {


### PR DESCRIPTION
## Summary
- scope SongManagerPage song title styling to its own page
- force pending song manager song title color to magenta

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1f86b12a88323b46ecf8719e23076