### PR TITLE
Enable async caching and confirm approval

### DIFF
--- a/BNKaraoke.Api/Controllers/SongController.cs
+++ b/BNKaraoke.Api/Controllers/SongController.cs
@@ -801,23 +801,8 @@ namespace BNKaraoke.Api.Controllers
 
                 if (!song.Mature && !string.IsNullOrWhiteSpace(song.YouTubeUrl))
                 {
-                    try
-                    {
-                        var cached = await _songCacheService.CacheSongAsync(song.Id, song.YouTubeUrl);
-                        if (cached)
-                        {
-                            song.Cached = true;
-                            await _context.SaveChangesAsync();
-                        }
-                        else
-                        {
-                            _logger.LogWarning("ApproveSong: Failed to cache song {SongId}", song.Id);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "ApproveSong: Error caching song {SongId}", song.Id);
-                    }
+                    _ = _songCacheService.CacheSongAsync(song.Id, song.YouTubeUrl);
+                    _logger.LogInformation("ApproveSong: Caching initiated for song {SongId}", song.Id);
                 }
 
                 _logger.LogInformation("ApproveSong: Song '{Title}' approved by {ApprovedBy} in {TotalElapsedMilliseconds} ms", song.Title, song.ApprovedBy, sw.ElapsedMilliseconds);

--- a/BNKaraoke.Api/Services/SongCacheService.cs
+++ b/BNKaraoke.Api/Services/SongCacheService.cs
@@ -163,6 +163,15 @@ namespace BNKaraoke.Api.Services
                     if (process.ExitCode == 0 && File.Exists(filePath))
                     {
                         _logger.LogInformation("Cached song {SongId} at {Path}", songId, filePath);
+                        song.Cached = true;
+                        try
+                        {
+                            await context.SaveChangesAsync(cancellationToken);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Error updating Cached flag for song {SongId}", songId);
+                        }
                         return true;
                     }
 

--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
@@ -209,6 +209,7 @@ const PendingSongManagerPage: React.FC = () => {
   };
 
   const handleApproveSong = async (songId: number, YouTubeUrl: string, token: string) => {
+    if (!window.confirm("Approve this song and start caching?")) return;
     try {
       const response = await fetch(API_ROUTES.APPROVE_SONGS, {
         method: "POST",


### PR DESCRIPTION
## Summary
- trigger background caching when approving songs
- persist cached status from SongCacheService
- add confirmation dialog before approving songs

## Testing
- `CI=true npm test --silent`
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b27dcc40bc8323a089d90b3f30641e