### PR TITLE
Refine YouTube selection modal UX

### DIFF
--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.css
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.css
@@ -230,19 +230,25 @@
 .youtube-modal {
   width: 80vw;
   max-width: 1600px;
+  height: 80vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .youtube-modal-content {
+  flex: 1;
   display: flex;
   gap: 20px;
   width: 100%;
+  overflow: hidden;
 }
 
 .youtube-list {
   width: 60%;
   min-width: 60%;
   flex: 0 0 60%;
-  max-height: 600px;
+  height: 100%;
   overflow-y: auto;
   padding-right: 25px;
   box-sizing: border-box;
@@ -262,6 +268,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  box-sizing: border-box;
 }
 
 .youtube-info {
@@ -292,10 +299,12 @@
   width: 40%;
   min-width: 40%;
   flex: 0 0 40%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
   background: rgba(0, 0, 0, 0.3);
+  overflow: hidden;
 }
 
 .youtube-fallback {
@@ -309,6 +318,10 @@
 
 .watch-link:hover {
   text-decoration: underline;
+}
+
+.youtube-item.selected {
+  border: 4px solid #22d3ee;
 }
 
 
@@ -503,7 +516,7 @@
 }
 
 .pending-song-manager .youtube-list {
-  max-height: 1200px;
+  height: 100%;
 }
 
 .pending-song-manager .youtube-preview iframe {

--- a/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/PendingSongManagerPage.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { API_ROUTES } from "../config/apiConfig";
 import "./PendingSongManagerPage.css";
+import toast from "react-hot-toast";
 
 interface PendingSong {
   id: number;
@@ -47,6 +48,13 @@ const PendingSongManagerPage: React.FC = () => {
   const [karaokeChannels, setKaraokeChannels] = useState<KaraokeChannel[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [youtubeError, setYoutubeError] = useState<string | null>(null);
+
+  useEffect(() => {
+    document.body.style.overflow = showYoutubeModal ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [showYoutubeModal]);
 
   const validateToken = () => {
     const token = localStorage.getItem("token");
@@ -223,7 +231,7 @@ const PendingSongManagerPage: React.FC = () => {
       if (!response.ok) {
         throw new Error(`Failed to approve song: ${response.status} ${response.statusText} - ${text}`);
       }
-      alert("Song approved successfully!");
+      toast.success("Song approved successfully!", { duration: 4000 });
       fetchPendingSongs(token);
       setShowManualInput(prev => ({ ...prev, [songId]: false }));
       setShowYoutubeModal(false);
@@ -385,7 +393,10 @@ const PendingSongManagerPage: React.FC = () => {
                 ) : youtubeResults.length > 0 ? (
                   <ul className="youtube-results">
                     {youtubeResults.map(video => (
-                      <li key={video.videoId} className="youtube-item">
+                      <li
+                        key={video.videoId}
+                        className={`youtube-item ${selectedVideo?.videoId === video.videoId ? "selected" : ""}`}
+                      >
                         <div className="youtube-info">
                           <p className="youtube-title">{video.title}</p>
                           <p className="youtube-meta">Channel: {video.channelTitle}</p>


### PR DESCRIPTION
## Summary
- lock body scroll when YouTube selection modal is open and constrain modal height to eliminate extra scrollbars
- show a 4 second toast after approving a song instead of a second confirmation dialog
- highlight the currently previewed YouTube result with a persistent border

## Testing
- `npm test --prefix bnkaraoke.web -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b28995c054832389c6617d1cc1263a