### PR TITLE
feat: add API URL dropdown for DJ login

### DIFF
--- a/BNKaraoke.DJ/Services/AuthService.cs
+++ b/BNKaraoke.DJ/Services/AuthService.cs
@@ -25,6 +25,15 @@ namespace BNKaraoke.DJ.Services
             Log.Information("[AUTH] Initialized with ApiUrl={ApiUrl}", _settingsService.Settings.ApiUrl);
         }
 
+        public void SetApiUrl(string apiUrl)
+        {
+            if (string.IsNullOrWhiteSpace(apiUrl)) return;
+            _httpClient.BaseAddress = new Uri(apiUrl);
+            _settingsService.Settings.ApiUrl = apiUrl;
+            _settingsService.SaveSettings(_settingsService.Settings);
+            Log.Information("[AUTH] API base URL set to {ApiUrl}", apiUrl);
+        }
+
         public async Task<LoginResult> LoginAsync(string userName, string password)
         {
             try

--- a/BNKaraoke.DJ/Views/LoginWindow.xaml
+++ b/BNKaraoke.DJ/Views/LoginWindow.xaml
@@ -36,6 +36,25 @@
                     <ColumnDefinition Width="100"/>
                     <ColumnDefinition Width="250"/>
                 </Grid.ColumnDefinitions>
+                <TextBlock Text="API URL"
+                           FontSize="18"
+                           FontWeight="Bold"
+                           Foreground="White"
+                           VerticalAlignment="Center"
+                           HorizontalAlignment="Right"
+                           Margin="0,0,10,0"/>
+                <ComboBox ItemsSource="{Binding AvailableApiUrls}"
+                          SelectedItem="{Binding SelectedApiUrl}"
+                          Width="250"
+                          Height="35"
+                          Grid.Column="1"
+                          HorizontalAlignment="Left"/>
+            </Grid>
+            <Grid Margin="0,10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="100"/>
+                    <ColumnDefinition Width="250"/>
+                </Grid.ColumnDefinitions>
                 <TextBlock Text="Phone"
                            FontSize="18"
                            FontWeight="Bold"

--- a/BNKaraoke.DJ/settings.json
+++ b/BNKaraoke.DJ/settings.json
@@ -1,3 +1,7 @@
 {
-  "ApiBaseUrl": "http://localhost:7290"
+  "AvailableApiUrls": [
+    "http://localhost:7290",
+    "https://api.bnkaraoke.com"
+  ],
+  "ApiUrl": "http://localhost:7290"
 }


### PR DESCRIPTION
## Summary
- allow choosing the API URL on the DJ login screen
- persist selected API URL in settings and update auth service
- include default API URLs in settings template

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b3020428188323b26487c743c2c40e