### PR TITLE
Fix queue reorder endpoint and use API-based caching

### DIFF
--- a/BNKaraoke.DJ/Services/ApiService.cs
+++ b/BNKaraoke.DJ/Services/ApiService.cs
@@ -318,7 +318,7 @@ namespace BNKaraoke.DJ.Services
                 var intQueueIds = queueIds.Select(id => int.Parse(id)).ToList();
                 var jsonPayload = JsonSerializer.Serialize(intQueueIds);
                 Log.Information("[APISERVICE] Reordering queue for EventId={EventId}, QueueIds={QueueIds}, Payload={Payload}", eventId, string.Join(",", queueIds), jsonPayload);
-                var response = await _httpClient.PutAsJsonAsync($"/api/dj/{eventId}/queue/reorder", intQueueIds);
+                var response = await _httpClient.PutAsJsonAsync($"/api/events/{eventId}/queue/reorder", intQueueIds);
                 if (!response.IsSuccessStatusCode)
                 {
                     var errorContent = await response.Content.ReadAsStringAsync();

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -487,13 +487,13 @@ namespace BNKaraoke.DJ.ViewModels
                                     }
                                 });
                             }
-                            else if (!string.IsNullOrEmpty(entry.YouTubeUrl))
+                            else if (entry.IsServerCached)
                             {
                                 _ = Task.Run(async () =>
                                 {
                                     try
                                     {
-                                        await _videoCacheService.CacheVideoAsync(entry.YouTubeUrl!, entry.SongId);
+                                        await _videoCacheService.CacheVideoAsync(entry.SongId);
                                         bool cached = _videoCacheService.IsVideoCached(entry.SongId);
                                         await Application.Current.Dispatcher.InvokeAsync(() => entry.IsVideoCached = cached);
                                         if (cached)

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -71,7 +71,7 @@ namespace BNKaraoke.DJ.ViewModels
             try
             {
                 Log.Information("[DJSCREEN VM] Starting ViewModel constructor");
-                _videoCacheService = videoCacheService ?? new VideoCacheService(_settingsService);
+                _videoCacheService = videoCacheService ?? new VideoCacheService(_settingsService, _apiService);
                 Log.Information("[DJSCREEN VM] VideoCacheService initialized, CachePath={CachePath}", _settingsService.Settings.VideoCachePath);
                 _signalRService = new SignalRService(
                     _userSessionService,


### PR DESCRIPTION
## Summary
- point reorder requests to `/api/events/{eventId}/queue/reorder`
- download cached videos from API instead of running yt-dlp locally
- wire `VideoCacheService` through `DJScreenViewModel`

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b478659d7883239699cb5635ae3765