### PR TITLE
Fix singer status handling and reorder payload

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -901,8 +901,9 @@ namespace BNKaraoke.Api.Controllers
                         {
                             UserId = ss.UserId,
                             DisplayName = ss.DisplayName.Length > 0 ? ss.DisplayName : ss.UserId,
-                            IsLoggedIn = ss.IsLoggedIn || (qs != null && qs.IsLoggedIn),
-                            IsJoined = ss.IsJoined,
+                            // Treat presence in the queue as logged in/joined even if SingerStatus is missing
+                            IsLoggedIn = ss.IsLoggedIn || qs != null,
+                            IsJoined = ss.IsJoined || qs != null,
                             IsOnBreak = ss.IsOnBreak
                         };
                     })
@@ -913,8 +914,9 @@ namespace BNKaraoke.Api.Controllers
                     {
                         UserId = qs.UserId,
                         DisplayName = qs.DisplayName.Length > 0 ? qs.DisplayName : qs.UserId,
-                        IsLoggedIn = qs.IsLoggedIn,
-                        IsJoined = false,
+                        // Singer has queue entries but no SingerStatus record; assume logged in and joined
+                        IsLoggedIn = true,
+                        IsJoined = true,
                         IsOnBreak = qs.IsOnBreak
                     })
                     .ToList();

--- a/BNKaraoke.Api/Data/ApplicationDbContext.cs
+++ b/BNKaraoke.Api/Data/ApplicationDbContext.cs
@@ -243,7 +243,8 @@ namespace BNKaraoke.Api.Data
             modelBuilder.Entity<Song>()
                 .Property(s => s.Cached).HasColumnName("Cached").HasDefaultValue(false);
             modelBuilder.Entity<Song>()
-                .Property(s => s.Mature).HasColumnName("Mature").HasDefaultValue(false);
+                // Map maturity flag to the underlying IsMature column
+                .Property(s => s.Mature).HasColumnName("IsMature").HasDefaultValue(false);
             modelBuilder.Entity<Song>()
                 .Property(s => s.Status).HasColumnName("Status");
             modelBuilder.Entity<Song>()

--- a/BNKaraoke.DJ/Services/ApiService.cs
+++ b/BNKaraoke.DJ/Services/ApiService.cs
@@ -310,15 +310,15 @@ namespace BNKaraoke.DJ.Services
             }
         }
 
-        public async Task ReorderQueueAsync(string eventId, List<string> queueIds)
+        public async Task ReorderQueueAsync(string eventId, List<QueuePosition> newOrder)
         {
             try
             {
                 ConfigureAuthorizationHeader();
-                var intQueueIds = queueIds.Select(id => int.Parse(id)).ToList();
-                var jsonPayload = JsonSerializer.Serialize(intQueueIds);
-                Log.Information("[APISERVICE] Reordering queue for EventId={EventId}, QueueIds={QueueIds}, Payload={Payload}", eventId, string.Join(",", queueIds), jsonPayload);
-                var response = await _httpClient.PutAsJsonAsync($"/api/events/{eventId}/queue/reorder", intQueueIds);
+                var request = new ReorderQueueRequest { NewOrder = newOrder };
+                var jsonPayload = JsonSerializer.Serialize(request);
+                Log.Information("[APISERVICE] Reordering queue for EventId={EventId}, Payload={Payload}", eventId, jsonPayload);
+                var response = await _httpClient.PutAsJsonAsync($"/api/events/{eventId}/queue/reorder", request);
                 if (!response.IsSuccessStatusCode)
                 {
                     var errorContent = await response.Content.ReadAsStringAsync();
@@ -326,11 +326,6 @@ namespace BNKaraoke.DJ.Services
                     throw new HttpRequestException($"Failed to reorder queue: {response.StatusCode} - {errorContent}");
                 }
                 Log.Information("[APISERVICE] Successfully reordered queue for EventId={EventId}", eventId);
-            }
-            catch (FormatException ex)
-            {
-                Log.Error("[APISERVICE] Failed to parse queue IDs for EventId={EventId}: {Message}, QueueIds={QueueIds}", eventId, ex.Message, string.Join(",", queueIds));
-                throw new ArgumentException("Invalid queue ID format", nameof(queueIds), ex);
             }
             catch (HttpRequestException ex)
             {

--- a/BNKaraoke.DJ/Services/IApiService.cs
+++ b/BNKaraoke.DJ/Services/IApiService.cs
@@ -18,7 +18,7 @@ namespace BNKaraoke.DJ.Services
         Task<List<QueueEntry>> GetLiveQueueAsync(string eventId);
         Task<List<QueueEntry>> GetSungQueueAsync(string eventId);
         Task<int> GetSungCountAsync(string eventId);
-        Task ReorderQueueAsync(string eventId, List<string> queueIds);
+        Task ReorderQueueAsync(string eventId, List<QueuePosition> newOrder);
         Task PlayAsync(string eventId, string queueId);
         Task PauseAsync(string eventId, string queueId);
         Task StopAsync(string eventId, string queueId);


### PR DESCRIPTION
## Summary
- Map song maturity to `IsMature` column
- Treat singers with queue entries as logged-in and joined
- Send queue reorder positions to API

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b48687c3a88323981f9d893b505c7c