### PR TITLE
Fix song maturity column mapping

### DIFF
--- a/BNKaraoke.Api/Data/ApplicationDbContext.cs
+++ b/BNKaraoke.Api/Data/ApplicationDbContext.cs
@@ -243,8 +243,8 @@ namespace BNKaraoke.Api.Data
             modelBuilder.Entity<Song>()
                 .Property(s => s.Cached).HasColumnName("Cached").HasDefaultValue(false);
             modelBuilder.Entity<Song>()
-                // Map maturity flag to the underlying IsMature column
-                .Property(s => s.Mature).HasColumnName("IsMature").HasDefaultValue(false);
+                // Map maturity flag to the underlying Mature column
+                .Property(s => s.Mature).HasColumnName("Mature").HasDefaultValue(false);
             modelBuilder.Entity<Song>()
                 .Property(s => s.Status).HasColumnName("Status");
             modelBuilder.Entity<Song>()


### PR DESCRIPTION
## Summary
- map Song.Mature property to database column `Mature`

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b48bdcf93483239064b58cba9b2e13