### PR TITLE
Sync queue singer statuses and show mature flag

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -453,6 +453,7 @@ namespace BNKaraoke.DJ.ViewModels
                             IsSingerJoined = dto.IsSingerJoined,
                             IsSingerOnBreak = dto.IsSingerOnBreak,
                             IsServerCached = dto.IsServerCached,
+                            IsMature = dto.IsMature,
                             VideoLength = ""
                         };
 


### PR DESCRIPTION
## Summary
- map IsMature from API queue DTO to queue entries so mature column shows correctly
- refresh queue entry singer status when singer data updates to keep queue colors in sync

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ecc2e7483239b2ba3ad4ada55e1