### PR TITLE
Fix queue reorder validation and sync singer status with queue colors

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -457,12 +457,18 @@ namespace BNKaraoke.DJ.ViewModels
                             VideoLength = ""
                         };
 
-                        var matchingSinger = Singers.FirstOrDefault(s => s.UserId == entry.RequestorUserName);
+                        var singerIds = entry.Singers != null && entry.Singers.Any()
+                            ? entry.Singers
+                            : new List<string> { entry.RequestorUserName };
+                        var matchingSinger = Singers.FirstOrDefault(s => singerIds.Contains(s.UserId));
                         if (matchingSinger != null)
                         {
+                            entry.IsSingerLoggedIn = matchingSinger.IsLoggedIn;
+                            entry.IsSingerJoined = matchingSinger.IsJoined;
                             entry.IsSingerOnBreak = matchingSinger.IsOnBreak;
-                            Log.Information("[DJSCREEN] Synced IsSingerOnBreak={IsSingerOnBreak} for QueueId={QueueId}, RequestorUserName={RequestorUserName}, SingerDisplayName={SingerDisplayName}",
-                                entry.IsSingerOnBreak, entry.QueueId, entry.RequestorUserName, matchingSinger.DisplayName);
+                            Log.Information("[DJSCREEN] Synced singer status for QueueId={QueueId}, RequestorUserName={RequestorUserName}, SingerDisplayName={SingerDisplayName}, LoggedIn={LoggedIn}, Joined={Joined}, OnBreak={OnBreak}",
+                                entry.QueueId, entry.RequestorUserName, matchingSinger.DisplayName,
+                                entry.IsSingerLoggedIn, entry.IsSingerJoined, entry.IsSingerOnBreak);
                         }
 
                         if (entry.Singers != null && entry.Singers.Any())
@@ -546,6 +552,7 @@ namespace BNKaraoke.DJ.ViewModels
                     }
                     OnPropertyChanged(nameof(QueueEntries));
                     Log.Information("[DJSCREEN] Loaded {Count} queue entries for event {EventId}", QueueEntries.Count, _currentEventId);
+                    SyncQueueSingerStatuses();
                 });
                 await UpdateQueueColorsAndRules();
             }


### PR DESCRIPTION
## Summary
- Allow queue reordering to operate on unplayed entries only and adjust positions relative to completed songs
- Sync queue entry colors with actual singer status instead of requestor data

## Testing
- `dotnet build BNKaraoke.Api/BNKaraoke.Api.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b49143201483238a8ae4c4f8bee183