### PR TITLE
Compute hold reason in hub

### DIFF
--- a/BNKaraoke.Api/Hubs/KaraokeDJHub.cs
+++ b/BNKaraoke.Api/Hubs/KaraokeDJHub.cs
@@ -101,6 +101,14 @@ namespace BNKaraoke.Api.Hubs
 
                             singerStatuses.TryGetValue(eq.RequestorUserName, out var status);
 
+                            var holdReason = string.Empty;
+                            if (status == null || !status.IsJoined)
+                                holdReason = "NotJoined";
+                            else if (!status.IsLoggedIn)
+                                holdReason = "NotLoggedIn";
+                            else if (status.IsOnBreak || eq.IsOnBreak)
+                                holdReason = "OnBreak";
+
                             return new EventQueueDto
                             {
                                 QueueId = eq.QueueId,
@@ -119,7 +127,7 @@ namespace BNKaraoke.Api.Hubs
                                 IsCurrentlyPlaying = eq.IsCurrentlyPlaying,
                                 SungAt = eq.SungAt,
                                 IsOnBreak = eq.IsOnBreak,
-                                HoldReason = eq.HoldReason ?? string.Empty,
+                                HoldReason = holdReason,
                                 IsUpNext = false,
                                 IsSingerLoggedIn = status?.IsLoggedIn ?? false,
                                 IsSingerJoined = status?.IsJoined ?? false,


### PR DESCRIPTION
## Summary
- avoid referencing missing EventQueue.HoldReason in KaraokeDJHub
- derive hold reason from singer status when building initial queue

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4b438eba88323bea26bf42e7e55cc