### PR TITLE
Broadcast event updates via SignalR

### DIFF
--- a/BNKaraoke.Api/Controllers/EventController.EventManagement.cs
+++ b/BNKaraoke.Api/Controllers/EventController.EventManagement.cs
@@ -305,6 +305,7 @@ namespace BNKaraoke.Api.Controllers
 
                 if (_hubContext != null)
                 {
+                    await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("EventUpdated", eventResponse);
                     await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", new { data = 0, action = $"Status_{existingEvent.Status}" });
                 }
 

--- a/bnkaraoke.web/src/hooks/useSignalR.ts
+++ b/bnkaraoke.web/src/hooks/useSignalR.ts
@@ -1,7 +1,7 @@
 // src/hooks/useSignalR.ts
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { HubConnectionBuilder, HubConnectionState, HubConnection, LogLevel, HttpTransportType, HttpClient, HttpRequest, HttpResponse } from '@microsoft/signalr';
-import { EventQueueItem, Song } from '../types';
+import { EventQueueItem, Song, Event } from '../types';
 import API_BASE_URL, { API_ROUTES } from '../config/apiConfig';
 
 interface EventQueueDto {
@@ -25,7 +25,8 @@ interface EventQueueDto {
 }
 
 interface UseSignalRProps {
-  currentEvent: { eventId: number; status: string } | null;
+  currentEvent: Event | null;
+  setCurrentEvent: React.Dispatch<React.SetStateAction<Event | null>>;
   isCurrentEventLive: boolean;
   checkedIn: boolean;
   navigate: (path: string) => void;
@@ -47,6 +48,7 @@ const HEALTH_CHECK_URL = `${API_BASE_URL}/api/events/health`;
 
 const useSignalR = ({
   currentEvent,
+  setCurrentEvent,
   isCurrentEventLive,
   checkedIn,
   navigate,
@@ -364,6 +366,12 @@ const useSignalR = ({
         queueItems = data;
       }
       processQueueData(queueItems, `QueueUpdated (${action})`);
+    });
+    connection.on("EventUpdated", (eventDto: Event) => {
+      console.log("[SIGNALR] EventUpdated received:", eventDto);
+      if (currentEvent && eventDto.eventId === currentEvent.eventId) {
+        setCurrentEvent(eventDto);
+      }
     });
     connection.on("QueuePlaying", (queueId: number, eventId: number, youTubeUrl?: string) => {
       if (eventId !== currentEvent?.eventId) return;

--- a/bnkaraoke.web/src/pages/Dashboard.tsx
+++ b/bnkaraoke.web/src/pages/Dashboard.tsx
@@ -17,7 +17,7 @@ import Modals from '../components/Modals';
 
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
-  const { checkedIn, isCurrentEventLive, currentEvent, setIsOnBreak, logout } = useEventContext();
+  const { checkedIn, isCurrentEventLive, currentEvent, setCurrentEvent, setIsOnBreak, logout } = useEventContext();
   const [myQueues, setMyQueues] = useState<{ [eventId: number]: EventQueueItem[] }>({});
   const [globalQueue, setGlobalQueue] = useState<EventQueueItem[]>([]);
   const [songDetailsMap, setSongDetailsMap] = useState<{ [songId: number]: Song }>({});
@@ -79,6 +79,7 @@ const Dashboard: React.FC = () => {
 
   const { signalRError, serverAvailable: signalRServerAvailable, queuesLoading } = useSignalR({
     currentEvent,
+    setCurrentEvent,
     isCurrentEventLive,
     checkedIn,
     navigate,


### PR DESCRIPTION
## Summary
- Broadcast EventUpdated message via SignalR when event settings change
- Update React SignalR hook and dashboard to refresh event state in real time

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `dotnet build BNKaraoke.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bb1b57808323961b4ae50a0fea20