### PR TITLE
Skip confirmation for auto-play

### DIFF
--- a/BNKaraoke.Api/Controllers/EventController.EventManagement.cs
+++ b/BNKaraoke.Api/Controllers/EventController.EventManagement.cs
@@ -305,6 +305,7 @@ namespace BNKaraoke.Api.Controllers
 
                 if (_hubContext != null)
                 {
+                    await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("EventUpdated", eventResponse);
                     await _hubContext.Clients.Group($"Event_{eventId}").SendAsync("QueueUpdated", new { data = 0, action = $"Status_{existingEvent.Status}" });
                 }
 

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -834,6 +834,9 @@ namespace BNKaraoke.DJ.ViewModels
 
         [RelayCommand]
         public async Task PlayQueueEntryAsync(QueueEntry? entry)
+            => await PlayQueueEntryAsync(entry, requireConfirmation: true);
+
+        public async Task PlayQueueEntryAsync(QueueEntry? entry, bool requireConfirmation)
         {
             Log.Information("[DJSCREEN] PlayQueueEntryAsync invoked for QueueId={QueueId}, SongTitle={SongTitle}, IsSingerOnBreak={IsSingerOnBreak}",
                 entry?.QueueId ?? -1, entry?.SongTitle ?? "Unknown", entry?.IsSingerOnBreak ?? false);
@@ -865,18 +868,21 @@ namespace BNKaraoke.DJ.ViewModels
 
             try
             {
-                string confirmMessage = (IsPlaying || IsVideoPaused)
-                    ? $"Play '{entry.SongTitle ?? "Unknown"}' by {entry.RequestorDisplayName ?? "Unknown"} now? This will stop the current song."
-                    : $"Play '{entry.SongTitle ?? "Unknown"}' by {entry.RequestorDisplayName ?? "Unknown"} now?";
-                var result = await Application.Current.Dispatcher.InvokeAsync(() =>
-                    MessageBox.Show(confirmMessage, "Confirm Song Playback", MessageBoxButton.YesNo, MessageBoxImage.Question));
-                Log.Information("[DJSCREEN] Confirmation dialog result for QueueId={QueueId}: {Result}", entry.QueueId, result);
-
-                if (result != MessageBoxResult.Yes)
+                if (requireConfirmation)
                 {
-                    Log.Information("[DJSCREEN] Playback of QueueId={QueueId} cancelled by user", entry.QueueId);
-                    await Task.CompletedTask;
-                    return;
+                    string confirmMessage = (IsPlaying || IsVideoPaused)
+                        ? $"Play '{entry.SongTitle ?? "Unknown"}' by {entry.RequestorDisplayName ?? "Unknown"} now? This will stop the current song."
+                        : $"Play '{entry.SongTitle ?? "Unknown"}' by {entry.RequestorDisplayName ?? "Unknown"} now?";
+                    var result = await Application.Current.Dispatcher.InvokeAsync(() =>
+                        MessageBox.Show(confirmMessage, "Confirm Song Playback", MessageBoxButton.YesNo, MessageBoxImage.Question));
+                    Log.Information("[DJSCREEN] Confirmation dialog result for QueueId={QueueId}: {Result}", entry.QueueId, result);
+
+                    if (result != MessageBoxResult.Yes)
+                    {
+                        Log.Information("[DJSCREEN] Playback of QueueId={QueueId} cancelled by user", entry.QueueId);
+                        await Task.CompletedTask;
+                        return;
+                    }
                 }
 
                 if ((IsPlaying || IsVideoPaused) && PlayingQueueEntry != null)
@@ -1225,7 +1231,7 @@ namespace BNKaraoke.DJ.ViewModels
                 if (nextEntry != null)
                 {
                     Log.Information("[DJSCREEN] Found next entry for auto-play: QueueId={QueueId}, SongTitle={SongTitle}", nextEntry.QueueId, nextEntry.SongTitle);
-                    await PlayQueueEntryAsync(nextEntry);
+                    await PlayQueueEntryAsync(nextEntry, requireConfirmation: false);
                 }
                 else
                 {

--- a/bnkaraoke.web/src/hooks/useSignalR.ts
+++ b/bnkaraoke.web/src/hooks/useSignalR.ts
@@ -1,7 +1,7 @@
 // src/hooks/useSignalR.ts
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { HubConnectionBuilder, HubConnectionState, HubConnection, LogLevel, HttpTransportType, HttpClient, HttpRequest, HttpResponse } from '@microsoft/signalr';
-import { EventQueueItem, Song } from '../types';
+import { EventQueueItem, Song, Event } from '../types';
 import API_BASE_URL, { API_ROUTES } from '../config/apiConfig';
 
 interface EventQueueDto {
@@ -25,7 +25,8 @@ interface EventQueueDto {
 }
 
 interface UseSignalRProps {
-  currentEvent: { eventId: number; status: string } | null;
+  currentEvent: Event | null;
+  setCurrentEvent: React.Dispatch<React.SetStateAction<Event | null>>;
   isCurrentEventLive: boolean;
   checkedIn: boolean;
   navigate: (path: string) => void;
@@ -47,6 +48,7 @@ const HEALTH_CHECK_URL = `${API_BASE_URL}/api/events/health`;
 
 const useSignalR = ({
   currentEvent,
+  setCurrentEvent,
   isCurrentEventLive,
   checkedIn,
   navigate,
@@ -364,6 +366,12 @@ const useSignalR = ({
         queueItems = data;
       }
       processQueueData(queueItems, `QueueUpdated (${action})`);
+    });
+    connection.on("EventUpdated", (eventDto: Event) => {
+      console.log("[SIGNALR] EventUpdated received:", eventDto);
+      if (currentEvent && eventDto.eventId === currentEvent.eventId) {
+        setCurrentEvent(eventDto);
+      }
     });
     connection.on("QueuePlaying", (queueId: number, eventId: number, youTubeUrl?: string) => {
       if (eventId !== currentEvent?.eventId) return;

--- a/bnkaraoke.web/src/pages/Dashboard.tsx
+++ b/bnkaraoke.web/src/pages/Dashboard.tsx
@@ -17,7 +17,7 @@ import Modals from '../components/Modals';
 
 const Dashboard: React.FC = () => {
   const navigate = useNavigate();
-  const { checkedIn, isCurrentEventLive, currentEvent, setIsOnBreak, logout } = useEventContext();
+  const { checkedIn, isCurrentEventLive, currentEvent, setCurrentEvent, setIsOnBreak, logout } = useEventContext();
   const [myQueues, setMyQueues] = useState<{ [eventId: number]: EventQueueItem[] }>({});
   const [globalQueue, setGlobalQueue] = useState<EventQueueItem[]>([]);
   const [songDetailsMap, setSongDetailsMap] = useState<{ [songId: number]: Song }>({});
@@ -79,6 +79,7 @@ const Dashboard: React.FC = () => {
 
   const { signalRError, serverAvailable: signalRServerAvailable, queuesLoading } = useSignalR({
     currentEvent,
+    setCurrentEvent,
     isCurrentEventLive,
     checkedIn,
     navigate,


### PR DESCRIPTION
## Summary
- Allow `PlayQueueEntryAsync` to skip user confirmation when auto-playing
- Auto-play requests now start songs without confirmation dialogs
- Fix `PlayQueueEntryAsync` signature so MVVM Toolkit command generation works

## Testing
- `npm --prefix bnkaraoke.web test -- --watchAll=false --passWithNoTests`
- `dotnet build BNKaraoke.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bb1b57808323961b4ae50a0fea20