### PR TITLE
Fix nullability warnings and relay command signature

### DIFF
--- a/BNKaraoke.DJ/Services/CacheSyncService.cs
+++ b/BNKaraoke.DJ/Services/CacheSyncService.cs
@@ -38,7 +38,7 @@ namespace BNKaraoke.DJ.Services
                 .Select(Path.GetFileNameWithoutExtension)
                 .Select(f => int.TryParse(f, out var id) ? id : (int?)null)
                 .Where(id => id.HasValue)
-                .Select(id => id.Value)
+                .Select(id => id!.Value)
                 .ToHashSet();
 
             var missing = manifest
@@ -59,7 +59,7 @@ namespace BNKaraoke.DJ.Services
                 .Select(Path.GetFileNameWithoutExtension)
                 .Select(f => int.TryParse(f, out var id) ? id : (int?)null)
                 .Where(id => id.HasValue)
-                .Select(id => id.Value)
+                .Select(id => id!.Value)
                 .ToHashSet();
 
             return manifest.Select(item => new CacheStatus

--- a/BNKaraoke.DJ/ViewModels/CacheManagerViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/CacheManagerViewModel.cs
@@ -21,7 +21,7 @@ namespace BNKaraoke.DJ.ViewModels
         public CacheManagerViewModel(CacheSyncService cacheSyncService)
         {
             _cacheSyncService = cacheSyncService;
-            CloseCommand = new RelayCommand<Window>(w => w.Close());
+            CloseCommand = new RelayCommand<Window>(w => w?.Close());
             DownloadCommand = new AsyncRelayCommand<CacheItem>(DownloadAsync);
         }
 

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -833,7 +833,12 @@ namespace BNKaraoke.DJ.ViewModels
         }
 
         [RelayCommand]
-        public async Task PlayQueueEntryAsync(QueueEntry? entry, bool requireConfirmation = true)
+        public async Task PlayQueueEntryAsync(QueueEntry? entry)
+        {
+            await PlayQueueEntryInternalAsync(entry, true);
+        }
+
+        private async Task PlayQueueEntryInternalAsync(QueueEntry? entry, bool requireConfirmation)
         {
             Log.Information("[DJSCREEN] PlayQueueEntryAsync invoked for QueueId={QueueId}, SongTitle={SongTitle}, IsSingerOnBreak={IsSingerOnBreak}",
                 entry?.QueueId ?? -1, entry?.SongTitle ?? "Unknown", entry?.IsSingerOnBreak ?? false);
@@ -1228,7 +1233,7 @@ namespace BNKaraoke.DJ.ViewModels
                 if (nextEntry != null)
                 {
                     Log.Information("[DJSCREEN] Found next entry for auto-play: QueueId={QueueId}, SongTitle={SongTitle}", nextEntry.QueueId, nextEntry.SongTitle);
-                    await PlayQueueEntryAsync(nextEntry, requireConfirmation: false);
+                    await PlayQueueEntryInternalAsync(nextEntry, requireConfirmation: false);
                 }
                 else
                 {

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Singers.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Singers.cs
@@ -201,7 +201,9 @@ namespace BNKaraoke.DJ.ViewModels
                 {
                     var singerIds = entry.Singers != null && entry.Singers.Any()
                         ? entry.Singers
-                        : new List<string> { entry.RequestorUserName };
+                        : !string.IsNullOrEmpty(entry.RequestorUserName)
+                            ? new List<string> { entry.RequestorUserName }
+                            : new List<string>();
                     var matchingSingers = singerIds
                         .Select(id => Singers.FirstOrDefault(s => s.UserId == id))
                         .Where(s => s != null)

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -21,7 +21,7 @@ namespace BNKaraoke.DJ.ViewModels
         private readonly SettingsService _settingsService = SettingsService.Instance;
         private readonly VideoCacheService? _videoCacheService;
         private readonly SignalRService? _signalRService;
-        private readonly CacheSyncService _cacheSyncService;
+        private readonly CacheSyncService _cacheSyncService = null!;
         private string? _currentEventId;
         private VideoPlayerWindow? _videoPlayerWindow;
         private bool _isLoginWindowOpen;

--- a/BNKaraoke.DJ/ViewModels/LoginWindowViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/LoginWindowViewModel.cs
@@ -23,7 +23,7 @@ namespace BNKaraoke.DJ.ViewModels
         [ObservableProperty] private string _password = string.Empty;
         [ObservableProperty] private bool _isBusy;
         [ObservableProperty] private string _errorMessage = string.Empty;
-        public ObservableCollection<string> AvailableApiUrls { get; }
+        public ObservableCollection<string> AvailableApiUrls { get; } = new();
         [ObservableProperty] private string _selectedApiUrl = string.Empty;
         public bool CanLogin => _rawUserName.Length == 10 && !string.IsNullOrWhiteSpace(Password);
 
@@ -32,7 +32,10 @@ namespace BNKaraoke.DJ.ViewModels
             _settingsService = SettingsService.Instance;
             try
             {
-                AvailableApiUrls = new ObservableCollection<string>(_settingsService.Settings.AvailableApiUrls);
+                foreach (var url in _settingsService.Settings.AvailableApiUrls)
+                {
+                    AvailableApiUrls.Add(url);
+                }
                 _selectedApiUrl = _settingsService.Settings.ApiUrl;
                 _authService = new AuthService();
                 _userSessionService = UserSessionService.Instance;


### PR DESCRIPTION
## Summary
- Guard window close command against null
- Suppress nullable initialization warnings and initialize API URL list
- Ensure cache diff handling and singer sync avoid nullable issues
- Split PlayQueueEntry into wrapper command for MVVM Toolkit compatibility

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ddd6da108323bfae61a83860dac4