### PR TITLE
fix song search pagination and hook dependency issues

### DIFF
--- a/BNKaraoke.Api/Controllers/SongController.cs
+++ b/BNKaraoke.Api/Controllers/SongController.cs
@@ -117,6 +117,16 @@ namespace BNKaraoke.Api.Controllers
                 query, artist, decade, genre, popularity, requestedBy, page, pageSize);
             try
             {
+                if (page < 1)
+                {
+                    _logger.LogWarning("Search: Page {Page} is less than 1", page);
+                    return BadRequest(new { error = "Page must be at least 1" });
+                }
+                if (pageSize < 1)
+                {
+                    _logger.LogWarning("Search: PageSize {PageSize} is less than 1", pageSize);
+                    return BadRequest(new { error = "PageSize must be at least 1" });
+                }
                 if (pageSize > 150)
                 {
                     _logger.LogWarning("Search: PageSize {PageSize} exceeds maximum limit of 150", pageSize);
@@ -426,6 +436,16 @@ namespace BNKaraoke.Api.Controllers
                 query, artist, status, page, pageSize);
             try
             {
+                if (page < 1)
+                {
+                    _logger.LogWarning("GetManageableSongs: Page {Page} is less than 1", page);
+                    return BadRequest(new { error = "Page must be at least 1" });
+                }
+                if (pageSize < 1)
+                {
+                    _logger.LogWarning("GetManageableSongs: PageSize {PageSize} is less than 1", pageSize);
+                    return BadRequest(new { error = "PageSize must be at least 1" });
+                }
                 if (pageSize > 150)
                 {
                     _logger.LogWarning("GetManageableSongs: PageSize {PageSize} exceeds maximum limit of 150", pageSize);

--- a/bnkaraoke.web/src/pages/SongManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/SongManagerPage.tsx
@@ -32,7 +32,7 @@ const SongManagerPage: React.FC = () => {
   const [filterArtist, setFilterArtist] = useState("");
   const [filterStatus, setFilterStatus] = useState("");
 
-  const validateToken = () => {
+  const validateToken = useCallback(() => {
     const token = localStorage.getItem("token");
     const userName = localStorage.getItem("userName");
     if (!token || !userName) {
@@ -67,7 +67,7 @@ const SongManagerPage: React.FC = () => {
       navigate("/login");
       return null;
     }
-  };
+  }, [navigate]);
 
   const fetchManageableSongs = useCallback(
     async (token: string) => {
@@ -115,7 +115,7 @@ const SongManagerPage: React.FC = () => {
     }
 
     fetchManageableSongs(token);
-  }, [navigate, fetchManageableSongs]);
+  }, [navigate, fetchManageableSongs, validateToken]);
 
   const handleEditSong = async (token: string) => {
     if (!editSong) return;


### PR DESCRIPTION
## Summary
- validate song search and management API pagination parameters to prevent server errors
- memoize SongManager token validation and include it in effect dependencies

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f6cb2b148323849dce8d0cf73c50