### PR TITLE
Add unique constraints for songs and queue entries

### DIFF
--- a/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
+++ b/BNKaraoke.Api/Controllers/EventController.QueueManagement.cs
@@ -133,7 +133,15 @@ namespace BNKaraoke.Api.Controllers
                 };
 
                 _context.EventQueues.Add(newQueueEntry);
-                await _context.SaveChangesAsync();
+                try
+                {
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogWarning(ex, "AddToQueue: Duplicate queue entry rejected for EventId={EventId}, SongId={SongId}, Requestor={Requestor}", eventId, queueDto.SongId, queueDto.RequestorUserName);
+                    return BadRequest("Song already in queue");
+                }
 
                 var singersList = new List<string>();
                 try

--- a/BNKaraoke.Api/Controllers/SongController.cs
+++ b/BNKaraoke.Api/Controllers/SongController.cs
@@ -1027,7 +1027,16 @@ namespace BNKaraoke.Api.Controllers
                     }
                 }
                 _context.Songs.Add(song);
-                await _context.SaveChangesAsync();
+                try
+                {
+                    await _context.SaveChangesAsync();
+                }
+                catch (DbUpdateException ex)
+                {
+                    _logger.LogWarning(ex, "RequestSong: Duplicate song insert rejected: Title={Title}, Artist={Artist}", song.Title, song.Artist);
+                    return BadRequest(new { error = $"Song with title {song.Title} by {song.Artist} already exists" });
+                }
+
                 _logger.LogInformation("RequestSong: Song '{Title}' added by {RequestedBy} in {TotalElapsedMilliseconds} ms", song.Title, song.RequestedBy, sw.ElapsedMilliseconds);
                 return Ok(new { message = "Song added to the party queue!" });
             }

--- a/BNKaraoke.Api/Data/ApplicationDbContext.cs
+++ b/BNKaraoke.Api/Data/ApplicationDbContext.cs
@@ -144,6 +144,10 @@ namespace BNKaraoke.Api.Data
             modelBuilder.Entity<EventQueue>()
                 .Property(eq => eq.UpdatedAt).HasColumnName("UpdatedAt").HasDefaultValueSql("CURRENT_TIMESTAMP");
 
+            modelBuilder.Entity<EventQueue>()
+                .HasIndex(eq => new { eq.EventId, eq.SongId, eq.RequestorUserName })
+                .IsUnique();
+
             // EventAttendance
             modelBuilder.Entity<EventAttendance>()
                 .ToTable("EventAttendance", "public")
@@ -273,6 +277,10 @@ namespace BNKaraoke.Api.Data
                 .Property(s => s.Danceability).HasColumnName("Danceability");
             modelBuilder.Entity<Song>()
                 .Property(s => s.Energy).HasColumnName("Energy");
+
+            modelBuilder.Entity<Song>()
+                .HasIndex(s => new { s.Title, s.Artist })
+                .IsUnique();
 
             // QueueItem
             modelBuilder.Entity<QueueItem>()


### PR DESCRIPTION
## Summary
- add composite unique index for song title and artist
- ensure event queue entries are unique per event, song, and requestor
- validate queue and song creation endpoints for duplicate records

## Testing
- `dotnet test BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fd3f08f0832387c1e61c6b1856b6