### PR TITLE
Use verbatim regex strings in AudioAnalysisService

### DIFF
--- a/BNKaraoke.Api/Services/AudioAnalysisService.cs
+++ b/BNKaraoke.Api/Services/AudioAnalysisService.cs
@@ -76,7 +76,8 @@ namespace BNKaraoke.Api.Services
             if (process == null) return 0f;
             string stderr = await process.StandardError.ReadToEndAsync();
             await process.WaitForExitAsync();
-            var match = Regex.Match(stderr, "silence_end: (?<time>\\d+\\.?\\d*)");
+            // Use a verbatim string to simplify the regular expression
+            var match = Regex.Match(stderr, @"silence_end: (?<time>\d+\.?\d*)");
             if (match.Success && float.TryParse(match.Groups["time"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var t))
             {
                 return t;
@@ -99,7 +100,8 @@ namespace BNKaraoke.Api.Services
             if (process == null) return 0f;
             string stderr = await process.StandardError.ReadToEndAsync();
             await process.WaitForExitAsync();
-            var match = Regex.Match(stderr, "Input Integrated:\s*(?<lufs>-?[0-9.]+)");
+            // Use a verbatim string to avoid escaping backslashes in the pattern
+            var match = Regex.Match(stderr, @"Input Integrated:\s*(?<lufs>-?[0-9.]+)");
             if (match.Success && float.TryParse(match.Groups["lufs"].Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var input))
             {
                 return TargetLoudness - input;


### PR DESCRIPTION
## Summary
- Replace regex patterns with verbatim strings to eliminate escape sequence issues
- Clarify pattern usage in `AudioAnalysisService`

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b618df122c8323821dbe27f2a8836b