### PR TITLE
feat: expose video manager and improve list keys

### DIFF
--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -542,6 +542,15 @@ const Header: React.FC = memo(() => {
                       Manage Pending Songs
                     </li>
                   )}
+                  {(roles.includes("Song Manager") || roles.includes("Queue Manager") || roles.includes("Application Manager")) && (
+                    <li
+                      className="dropdown-item"
+                      onClick={() => handleNavigation("/video-manager")}
+                      onTouchStart={() => handleNavigation("/video-manager")}
+                    >
+                      Manage Videos
+                    </li>
+                  )}
                   {(roles.includes("User Manager") || roles.includes("Application Manager")) && (
                     <li
                       className="dropdown-item"
@@ -787,6 +796,15 @@ const Header: React.FC = memo(() => {
                     onTouchStart={() => handleNavigation("/pending-song-manager")}
                   >
                     Manage Pending Songs
+                  </li>
+                )}
+                {(roles.includes("Song Manager") || roles.includes("Queue Manager") || roles.includes("Application Manager")) && (
+                  <li
+                    className="dropdown-item"
+                    onClick={() => handleNavigation("/video-manager")}
+                    onTouchStart={() => handleNavigation("/video-manager")}
+                  >
+                    Manage Videos
                   </li>
                 )}
                 {(roles.includes("User Manager") || roles.includes("Application Manager")) && (

--- a/bnkaraoke.web/src/pages/SongManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/SongManagerPage.tsx
@@ -249,8 +249,8 @@ const SongManagerPage: React.FC = () => {
           {error && <p className="error-text">{error}</p>}
           {manageableSongs.length > 0 ? (
             <ul className="song-list">
-              {manageableSongs.map(song => (
-                <li key={song.Id} className="song-item">
+              {manageableSongs.map((song, index) => (
+                <li key={`${song.Id}-${index}`} className="song-item">
                   <div className="song-info">
                     <p className="song-title">{song.Title} - {song.Artist}</p>
                     <p className="song-text">Genre: {song.Genre || "Unknown"} | Status: {song.Status}</p>


### PR DESCRIPTION
## Summary
- add Manage Videos option to Admin menu
- ensure unique keys for song list items to silence React warning

## Testing
- `CI=true npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b61aab51d88323aa2b3f706f11cb4e