### PR TITLE
Fix video manager pending song filter

### DIFF
--- a/bnkaraoke.web/src/pages/VideoManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/VideoManagerPage.tsx
@@ -20,9 +20,9 @@ interface SongVideo {
   MusicBrainzId: string | null;
   LastFmPlaycount: number | null;
   Valence: number | null;
-  NormalizationGain: number | null;
-  FadeStartTime: number | null;
-  IntroMuteDuration: number | null;
+  NormalizationGain?: number | null;
+  FadeStartTime?: number | null;
+  IntroMuteDuration?: number | null;
 }
 
 const VideoManagerPage: React.FC = () => {
@@ -117,9 +117,9 @@ const VideoManagerPage: React.FC = () => {
 
   const pendingSongs = songs.filter(
     (s) =>
-      s.NormalizationGain === null ||
-      s.FadeStartTime === null ||
-      s.IntroMuteDuration === null
+      s.NormalizationGain == null ||
+      s.FadeStartTime == null ||
+      s.IntroMuteDuration == null
   );
 
   return (


### PR DESCRIPTION
## Summary
- show songs with missing video analysis values on the Manage Videos page
- allow optional analysis fields in SongVideo interface

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b623659f9c8323b112b1988b353fd0