### PR TITLE
Fix video analysis field mapping and add preview

### DIFF
--- a/bnkaraoke.web/src/config/apiConfig.ts
+++ b/bnkaraoke.web/src/config/apiConfig.ts
@@ -55,6 +55,7 @@ export const API_ROUTES = {
   API_MANUAL_CACHE_STATUS: `${API_BASE_URL}/api/maintenance/manual-cache/status`,
   API_MATURE_NOT_CACHED: `${API_BASE_URL}/api/maintenance/mature-not-cached`,
   VIDEO_ANALYZE: `${API_BASE_URL}/api/songs`,
+  CACHE_VIDEO: `${API_BASE_URL}/api/cache`,
 };
 
 export default API_BASE_URL;

--- a/bnkaraoke.web/src/pages/VideoManagerPage.css
+++ b/bnkaraoke.web/src/pages/VideoManagerPage.css
@@ -52,6 +52,12 @@
   border: none;
 }
 
+.analysis-modal video {
+  width: 100%;
+  height: 315px;
+  margin-bottom: 15px;
+}
+
 .analysis-fields {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- show cached video preview when analyzing a song
- map analysis results to proper fields and clean up previews
- expose cache API route for video fetching

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b63a1f04d88323a9f93ec29d889b14