### PR TITLE
fix: ensure video manager fetches songs

### DIFF
--- a/bnkaraoke.web/src/pages/VideoManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/VideoManagerPage.tsx
@@ -116,9 +116,16 @@ const VideoManagerPage: React.FC = () => {
   }, [navigate]);
 
   useEffect(() => {
-    const token = validateToken();
-    if (!token) return;
-    fetchSongs(token);
+    const loadSongs = async () => {
+      const token = validateToken();
+      if (!token) return;
+      try {
+        await fetchSongs(token);
+      } catch (err) {
+        console.error("[VIDEO_MANAGER] Failed to fetch songs", err);
+      }
+    };
+    loadSongs();
   }, [validateToken, fetchSongs]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure Manage Videos page loads songs by validating token and fetching asynchronously
- add error logging when song fetching fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66c801d948323aa8315a5676b1a08