### PR TITLE
Include video analysis fields in manageable songs

### DIFF
--- a/BNKaraoke.Api/Controllers/SongController.cs
+++ b/BNKaraoke.Api/Controllers/SongController.cs
@@ -499,7 +499,11 @@ namespace BNKaraoke.Api.Controllers
                         s.YouTubeUrl,
                         s.MusicBrainzId,
                         s.LastFmPlaycount,
-                        s.Valence
+                        s.Valence,
+                        s.Cached,
+                        s.NormalizationGain,
+                        s.FadeStartTime,
+                        s.IntroMuteDuration
                     })
                     .ToListAsync();
                 _logger.LogInformation("GetManageableSongs: Songs query took {ElapsedMilliseconds} ms, found {TotalSongs} songs, returning {SongCount} for page {Page} in {TotalElapsedMilliseconds} ms",


### PR DESCRIPTION
## Summary
- return `Cached`, `NormalizationGain`, `FadeStartTime`, and `IntroMuteDuration` from `GetManageableSongs` for video management

## Testing
- `dotnet test BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b66e2bf6e883239bf66c186b7aa0f7