### PR TITLE
Show video analysis details and avoid default mute/fade

### DIFF
--- a/BNKaraoke.Api/Controllers/SongController.cs
+++ b/BNKaraoke.Api/Controllers/SongController.cs
@@ -624,7 +624,9 @@ namespace BNKaraoke.Api.Controllers
                 {
                     song.NormalizationGain,
                     song.FadeStartTime,
-                    song.IntroMuteDuration
+                    song.IntroMuteDuration,
+                    result.InputLoudness,
+                    result.Duration
                 });
             }
             catch (Exception ex)

--- a/bnkaraoke.web/src/pages/VideoManagerPage.css
+++ b/bnkaraoke.web/src/pages/VideoManagerPage.css
@@ -58,6 +58,15 @@
   margin-bottom: 15px;
 }
 
+.analysis-details {
+  margin-bottom: 15px;
+  font-size: 0.9rem;
+}
+
+.analysis-details p {
+  margin: 4px 0;
+}
+
 .analysis-fields {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- prevent intro mute and fade from applying automatically in analysis modal
- display detailed analysis results including loudness, duration, and recommended normalization
- expose extra analysis data from API

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b70fba25248323bf66f9ee617f1554