### PR TITLE
Handle fade and mute metadata in DJ console

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -725,15 +725,21 @@ namespace BNKaraoke.DJ.ViewModels
 
                 if (TimeSpan.TryParseExact(targetEntry.VideoLength, @"m\:ss", null, out var duration))
                 {
-                    _totalDuration = duration;
-                    SongDuration = duration;
+                    var effectiveSeconds = duration.TotalSeconds;
+                    if (targetEntry.FadeStartTime.HasValue && targetEntry.FadeStartTime.Value > 0 &&
+                        targetEntry.FadeStartTime.Value + 8 < effectiveSeconds)
+                    {
+                        effectiveSeconds = targetEntry.FadeStartTime.Value + 8;
+                    }
+                    _totalDuration = TimeSpan.FromSeconds(effectiveSeconds);
+                    SongDuration = _totalDuration.Value;
                     await Application.Current.Dispatcher.InvokeAsync(() =>
                     {
-                        TimeRemainingSeconds = (int)(duration.TotalSeconds);
-                        TimeRemaining = duration.ToString(@"m\:ss");
+                        TimeRemainingSeconds = (int)effectiveSeconds;
+                        TimeRemaining = _totalDuration.Value.ToString(@"m\:ss");
                         OnPropertyChanged(nameof(SongDuration));
                         NotifyAllProperties();
-                        Log.Information("[DJSCREEN] Set total duration: {Duration}", duration);
+                        Log.Information("[DJSCREEN] Set total duration: {Duration}", _totalDuration);
                     });
                 }
                 else
@@ -1046,15 +1052,21 @@ namespace BNKaraoke.DJ.ViewModels
 
                 if (TimeSpan.TryParseExact(targetEntry.VideoLength, @"m\:ss", null, out var duration))
                 {
-                    _totalDuration = duration;
-                    SongDuration = duration;
+                    var effectiveSeconds = duration.TotalSeconds;
+                    if (targetEntry.FadeStartTime.HasValue && targetEntry.FadeStartTime.Value > 0 &&
+                        targetEntry.FadeStartTime.Value + 8 < effectiveSeconds)
+                    {
+                        effectiveSeconds = targetEntry.FadeStartTime.Value + 8;
+                    }
+                    _totalDuration = TimeSpan.FromSeconds(effectiveSeconds);
+                    SongDuration = _totalDuration.Value;
                     await Application.Current.Dispatcher.InvokeAsync(() =>
                     {
-                        TimeRemainingSeconds = (int)(duration.TotalSeconds);
-                        TimeRemaining = duration.ToString(@"m\:ss");
+                        TimeRemainingSeconds = (int)effectiveSeconds;
+                        TimeRemaining = _totalDuration.Value.ToString(@"m\:ss");
                         OnPropertyChanged(nameof(SongDuration));
                         NotifyAllProperties();
-                        Log.Information("[DJSCREEN] Set total duration: {Duration}", duration);
+                        Log.Information("[DJSCREEN] Set total duration: {Duration}", _totalDuration);
                     });
                 }
                 else

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -527,6 +527,9 @@ namespace BNKaraoke.DJ.ViewModels
                             IsSingerOnBreak = dto.IsSingerOnBreak,
                             IsServerCached = dto.IsServerCached,
                             IsMature = dto.IsMature,
+                            NormalizationGain = dto.NormalizationGain,
+                            FadeStartTime = dto.FadeStartTime,
+                            IntroMuteDuration = dto.IntroMuteDuration,
                             VideoLength = ""
                         };
 
@@ -673,7 +676,10 @@ namespace BNKaraoke.DJ.ViewModels
                           IsSingerJoined = dto.IsSingerJoined,
                           IsSingerOnBreak = dto.IsSingerOnBreak,
                           IsServerCached = dto.IsServerCached,
-                          IsMature = dto.IsMature
+                          IsMature = dto.IsMature,
+                          NormalizationGain = dto.NormalizationGain,
+                          FadeStartTime = dto.FadeStartTime,
+                          IntroMuteDuration = dto.IntroMuteDuration
                       };
                     // entry.IsVideoCached = _videoCacheService?.IsVideoCached(entry.SongId) ?? false;
                     QueueEntries.Add(entry);


### PR DESCRIPTION
## Summary
- read normalization, fade, and intro mute metadata when loading queue entries
- adjust playback timing to end at fade completion so countdown timer stops appropriately

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b73b2542f083238194c2216d488220