### PR TITLE
Improve fade and playback controls

### DIFF
--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -79,17 +79,17 @@
                     </Border.Style>
                     <TextBlock Text="{Binding TimeRemaining}" FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                 </Border>
-                <Border Width="80" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center"
+                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center"
                         Visibility="{Binding PlayingQueueEntry.FadeStartTime, Converter={StaticResource PositiveVisibilityConverter}}">
                     <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
-                        <Run Text="Fade "/>
+                        <Run Text="FO: "/>
                         <Run Text="{Binding PlayingQueueEntry.FadeStartTime, Converter={StaticResource SecondsToTimeConverter}}"/>
                     </TextBlock>
                 </Border>
-                <Border Width="80" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center"
+                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center"
                         Visibility="{Binding PlayingQueueEntry.IntroMuteDuration, Converter={StaticResource PositiveVisibilityConverter}}">
                     <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
-                        <Run Text="Mute "/>
+                        <Run Text="SM: "/>
                         <Run Text="{Binding PlayingQueueEntry.IntroMuteDuration, Converter={StaticResource SecondsToTimeConverter}}"/>
                     </TextBlock>
                 </Border>


### PR DESCRIPTION
## Summary
- shorten Fade and Start Mute indicators to "FO:" and "SM:" with expanded button width
- track slider position using absolute playback time and stop at fade point +8 seconds
- show full song length on slider while countdown uses fade end

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b7412495148323b73997845b880fb4