### PR TITLE
Handle stale now-playing tracks when joining events

### DIFF
--- a/BNKaraoke.DJ/Services/ApiService.cs
+++ b/BNKaraoke.DJ/Services/ApiService.cs
@@ -339,6 +339,28 @@ namespace BNKaraoke.DJ.Services
             }
         }
 
+        public async Task ResetNowPlayingAsync(string eventId)
+        {
+            try
+            {
+                ConfigureAuthorizationHeader();
+                Log.Information("[APISERVICE] Resetting now playing for EventId={EventId}", eventId);
+                var response = await _httpClient.PostAsync($"/api/dj/{eventId}/queue/reset-now-playing", null);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorContent = await response.Content.ReadAsStringAsync();
+                    Log.Error("[APISERVICE] Failed to reset now playing for EventId={EventId}: Status={StatusCode}, Error={Error}", eventId, response.StatusCode, errorContent);
+                    throw new HttpRequestException($"Failed to reset now playing: {response.StatusCode} - {errorContent}");
+                }
+                Log.Information("[APISERVICE] Reset now playing for EventId={EventId}", eventId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[APISERVICE] Failed to reset now playing for EventId={EventId}: {Message}", eventId, ex.Message);
+                throw;
+            }
+        }
+
         public async Task PlayAsync(string eventId, string queueId)
         {
             try

--- a/BNKaraoke.DJ/Services/IApiService.cs
+++ b/BNKaraoke.DJ/Services/IApiService.cs
@@ -19,6 +19,7 @@ namespace BNKaraoke.DJ.Services
         Task<List<QueueEntry>> GetSungQueueAsync(string eventId);
         Task<int> GetSungCountAsync(string eventId);
         Task ReorderQueueAsync(string eventId, List<QueuePosition> newOrder);
+        Task ResetNowPlayingAsync(string eventId);
         Task PlayAsync(string eventId, string queueId);
         Task PauseAsync(string eventId, string queueId);
         Task StopAsync(string eventId, string queueId);

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Header.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Header.cs
@@ -179,6 +179,7 @@ namespace BNKaraoke.DJ.ViewModels
                     Log.Information("[DJSCREEN] Joined event: {EventId}, {EventCode}", _currentEventId, eventCode);
                     if (_currentEventId != null)
                     {
+                        await _apiService.ResetNowPlayingAsync(_currentEventId);
                         await InitializeSignalRAsync(_currentEventId);
                     }
                     QueueEntries.Clear();


### PR DESCRIPTION
## Summary
- mark any existing playing entries as sung before setting a new now playing track
- add endpoint and client hook to reset any lingering now-playing songs when a DJ joins an event

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b74692aad483238626993b012a690e