### PR TITLE
Fix queue song details reset and lint error

### DIFF
--- a/bnkaraoke.web/src/hooks/useSignalR.ts
+++ b/bnkaraoke.web/src/hooks/useSignalR.ts
@@ -263,17 +263,21 @@ const useSignalR = ({
     });
 
     queueItems.forEach(item => {
-      setSongDetailsMap(prev => ({
-        ...prev,
-        [item.songId]: {
-          id: item.songId,
-          title: item.songTitle || `Song ${item.songId}`,
-          artist: item.songArtist || 'Unknown',
-          status: item.status || 'Active',
-          requestDate: null,
-          requestedBy: item.requestorUserName || null,
-        },
-      }));
+      setSongDetailsMap(prev => {
+        const existing = prev[item.songId];
+        return {
+          ...prev,
+          [item.songId]: {
+            ...existing,
+            id: item.songId,
+            title: item.songTitle ?? existing?.title ?? `Song ${item.songId}`,
+            artist: item.songArtist ?? existing?.artist ?? 'Unknown',
+            status: item.status ?? existing?.status ?? 'Active',
+            requestDate: existing?.requestDate ?? null,
+            requestedBy: item.requestorUserName ?? existing?.requestedBy ?? null,
+          },
+        };
+      });
     });
   }, [currentEvent, setGlobalQueue, setMyQueues, setSongDetailsMap]);
 

--- a/bnkaraoke.web/src/pages/VideoManagerPage.tsx
+++ b/bnkaraoke.web/src/pages/VideoManagerPage.tsx
@@ -226,7 +226,12 @@ const VideoManagerPage: React.FC = () => {
     video.muted = false;
     video.currentTime = 0;
     handleTimeUpdate();
-    video.play().catch(() => {});
+    video
+      .play()
+      .catch((err) => {
+        // Log the error rather than using an empty handler to satisfy lint rules
+        console.error("Video playback failed", err);
+      });
     video.addEventListener("timeupdate", handleTimeUpdate);
     video.addEventListener("loadedmetadata", handleTimeUpdate);
 


### PR DESCRIPTION
## Summary
- Avoid resetting song details to placeholders when queue updates lack title and artist
- Log video playback errors instead of using empty arrow function

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b749ca0fcc83238b9ab817d641e646