### PR TITLE
Order recent approvals by latest approval

### DIFF
--- a/BNKaraoke.Api/Controllers/ExploreController.cs
+++ b/BNKaraoke.Api/Controllers/ExploreController.cs
@@ -34,7 +34,7 @@ namespace BNKaraoke.Api.Controllers
                 var songs = await _context.Songs
                     .AsNoTracking()
                     .Where(s => s.Status == "active" && s.ApprovedBy != null)
-                    .OrderByDescending(s => s.RequestDate ?? DateTime.MinValue)
+                    .OrderByDescending(s => s.ApprovedDate ?? DateTime.MinValue)
                     .ThenByDescending(s => s.Id)
                     .Take(50)
                     .Select(s => new
@@ -50,6 +50,7 @@ namespace BNKaraoke.Api.Controllers
                         youTubeUrl = s.YouTubeUrl,
                         spotifyId = s.SpotifyId,
                         approvedBy = s.ApprovedBy,
+                        approvedDate = s.ApprovedDate,
                         bpm = s.Bpm,
                         requestDate = s.RequestDate,
                         musicBrainzId = s.MusicBrainzId,

--- a/BNKaraoke.Api/Controllers/SongController.cs
+++ b/BNKaraoke.Api/Controllers/SongController.cs
@@ -928,6 +928,7 @@ namespace BNKaraoke.Api.Controllers
                 song.YouTubeUrl = request.YouTubeUrl;
                 song.Status = "active";
                 song.ApprovedBy = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                song.ApprovedDate = DateTime.UtcNow;
                 if (string.IsNullOrEmpty(song.ApprovedBy))
                 {
                     _logger.LogWarning("ApproveSong: ApprovedBy is null. Claims: {Claims}", string.Join(", ", User.Claims.Select(c => $"{c.Type}: {c.Value}")));

--- a/BNKaraoke.Api/Models/Song.cs
+++ b/BNKaraoke.Api/Models/Song.cs
@@ -29,6 +29,7 @@ namespace BNKaraoke.Api.Models
         public DateTime? RequestDate { get; set; }
         public string? RequestedBy { get; set; }
         public string? ApprovedBy { get; set; }
+        public DateTime? ApprovedDate { get; set; }
         public float? NormalizationGain { get; set; }
         public float? FadeStartTime { get; set; }
         public float? IntroMuteDuration { get; set; }

--- a/Scripts/ApiMaintenance.sql
+++ b/Scripts/ApiMaintenance.sql
@@ -3,6 +3,9 @@ ALTER TABLE public."Songs" ADD COLUMN IF NOT EXISTS "Cached" boolean NOT NULL DE
 -- Add Mature column to Songs table
 ALTER TABLE public."Songs" ADD COLUMN IF NOT EXISTS "Mature" boolean NOT NULL DEFAULT false;
 
+-- Add ApprovedDate column to Songs table
+ALTER TABLE public."Songs" ADD COLUMN IF NOT EXISTS "ApprovedDate" timestamptz;
+
 -- Insert settings for cache path and download delay
 INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('CacheStoragePath', '/var/bnkaraoke/cache');
 INSERT INTO public."ApiSettings" ("SettingKey", "SettingValue") VALUES ('CacheDownloadDelaySeconds', '5');

--- a/bnkaraoke.web/src/pages/ExploreSongs.tsx
+++ b/bnkaraoke.web/src/pages/ExploreSongs.tsx
@@ -67,8 +67,22 @@ const ExploreSongs: React.FC = () => {
     connection.on('SongApproved', (song: { id: number; title: string; artist: string }) => {
       toast.success(`Song approved: ${song.title} - ${song.artist}`);
       if (showRecentRef.current) {
-        const approved: Song = { id: song.id, title: song.title, artist: song.artist, status: 'active' };
-        setBrowseSongs(prev => [approved, ...prev].slice(0, 50));
+        const approved: Song = {
+          id: song.id,
+          title: song.title,
+          artist: song.artist,
+          status: 'active',
+          approvedDate: new Date().toISOString(),
+        };
+        setBrowseSongs(prev =>
+          [approved, ...prev]
+            .sort(
+              (a, b) =>
+                new Date(b.approvedDate || 0).getTime() -
+                new Date(a.approvedDate || 0).getTime()
+            )
+            .slice(0, 50)
+        );
       }
     });
 
@@ -463,7 +477,11 @@ const ExploreSongs: React.FC = () => {
             throw new Error('Recent approvals fetch failed');
           }
           const data = await response.json();
-          const songs: Song[] = data.songs || [];
+          const songs: Song[] = (data.songs || []).sort(
+            (a: Song, b: Song) =>
+              new Date(b.approvedDate || 0).getTime() -
+              new Date(a.approvedDate || 0).getTime()
+          );
           setBrowseSongs(songs);
           setTotalPages(1);
           setIsLoading(false);

--- a/bnkaraoke.web/src/types.ts
+++ b/bnkaraoke.web/src/types.ts
@@ -12,6 +12,7 @@ export interface Song {
   popularity?: number;
   requestDate?: string | null;
   requestedBy?: string | null;
+  approvedDate?: string | null;
   spotifyId?: string;
   valence?: number;
   decade?: string;


### PR DESCRIPTION
## Summary
- track approval time with new `ApprovedDate` property on songs
- sort recent approvals by `ApprovedDate` so newest appear first in API and browse page
- provide SQL snippet to add `ApprovedDate` column and ensure gitignore has no binary diff

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dotnet test` *(fails: command not found)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b75d487a888323abaa18c89fb9457b