### PR TITLE
Add song search and back button to Video Manager

### DIFF
--- a/bnkaraoke.web/src/pages/VideoManagerPage.css
+++ b/bnkaraoke.web/src/pages/VideoManagerPage.css
@@ -4,6 +4,34 @@
   min-height: 100vh;
   padding: 20px;
   font-family: Arial, sans-serif;
+  display: flex;
+  flex-direction: column;
+}
+
+.video-manager-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.search-section {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.pending-section {
+  flex: 2;
+  overflow-y: auto;
+}
+
+.search-controls {
+  margin-bottom: 10px;
+  display: flex;
+  gap: 10px;
+}
+
+.back-button {
+  padding: 8px 12px;
 }
 
 .video-manager-container table {


### PR DESCRIPTION
## Summary
- Add header with "Back to Dashboard" button
- Introduce top section to search analyzed songs and open them for editing
- Adjust layout and styles so search fills top third and pending songs fill bottom two thirds

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc --noEmit` (prints help, no tsconfig)

------
https://chatgpt.com/codex/tasks/task_e_68b7713f0b18832380bbd50eb12cc017