### PR TITLE
feat: add total pending count and refresh to video manager

### DIFF
--- a/bnkaraoke.web/src/pages/VideoManagerPage.css
+++ b/bnkaraoke.web/src/pages/VideoManagerPage.css
@@ -24,6 +24,20 @@
   overflow-y: auto;
 }
 
+.pending-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.refresh-button {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.2rem;
+}
+
 .search-controls {
   margin-bottom: 10px;
   display: flex;


### PR DESCRIPTION
## Summary
- display total number of songs pending analysis in Manage Videos page
- show refresh control and fetch 20 songs per request

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b793ead5288323a2fec454b946f12c