### PR TITLE
fix: keep mobile search controls on same line

### DIFF
--- a/bnkaraoke.web/src/pages/AddRequests.css
+++ b/bnkaraoke.web/src/pages/AddRequests.css
@@ -338,18 +338,21 @@
     padding: 10px;
   }
   .search-bar-container {
-    flex-wrap: wrap;
-    gap: 6px;
+    flex-wrap: nowrap;
+    gap: 4px;
   }
   .search-bar {
     font-size: 0.9em;
     padding: 6px;
+    flex: 1 1 auto;
   }
-  .search-button, .reset-button {
-    padding: 6px;
+  .search-button,
+  .reset-button {
+    padding: 4px;
     font-size: 0.9em;
-    min-height: 44px;
-    width: 100%;
+    min-height: 36px;
+    width: auto;
+    flex: 0 0 auto;
   }
   .added-songs-section {
     margin-top: 15px;


### PR DESCRIPTION
## Summary
- prevent mobile search buttons from wrapping to a new line
- reduce mobile search button dimensions to fit within 360px width

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b865a5a5f08323b9ae621b10f7ff03