### PR TITLE
Fix mobile search results card width

### DIFF
--- a/bnkaraoke.web/src/pages/PendingRequests.css
+++ b/bnkaraoke.web/src/pages/PendingRequests.css
@@ -203,9 +203,13 @@
   }
   .song-list {
     max-height: 300px;
+    padding-right: 10px; /* Reserve space for scrollbar */
+    box-sizing: border-box;
   }
   .song-item {
     padding: 10px;
+    width: 100%;
+    box-sizing: border-box; /* Prevent overflow on mobile */
   }
   .song-title {
     font-size: 1em;


### PR DESCRIPTION
## Summary
- add padding and box-sizing to mobile song list and items to prevent scrollbar overlap

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b876ac2e588323ae5cce0bb4f5d21b