### PR TITLE
fix: prevent mobile input zoom

### DIFF
--- a/bnkaraoke.web/public/index.html
+++ b/bnkaraoke.web/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />

--- a/bnkaraoke.web/src/components/SearchBar.css
+++ b/bnkaraoke.web/src/components/SearchBar.css
@@ -106,8 +106,8 @@
     flex: 0 0 65%; /* Shrink input to leave room for icons */
     min-width: 0;
     padding: 2px;
-    font-size: 12px;
-    min-height: 24px; /* Match icons and browse button */
+    font-size: 16px;
+    min-height: 32px; /* Larger font requires more height */
     overflow-x: auto;
     white-space: nowrap;
     border: none;
@@ -194,8 +194,8 @@
     flex: 0 0 65%; /* Shrink input to leave room for icons */
     min-width: 0;
     padding: 2px;
-    font-size: 10px;
-    min-height: 22px; /* Match icons and browse button */
+    font-size: 16px;
+    min-height: 32px; /* Larger font requires more height */
     overflow-x: auto;
     white-space: nowrap;
     border: none;

--- a/bnkaraoke.web/src/index.css
+++ b/bnkaraoke.web/src/index.css
@@ -1,4 +1,8 @@
 /* src\index.css */
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',


### PR DESCRIPTION
## Summary
- stop iOS from zooming inputs by locking mobile scale
- keep text size steady on Safari and enlarge search bar input on small screens

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87d287af4832398740c072dd66523