### PR TITLE
Improve mobile padding and conditional preselect button

### DIFF
--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -539,17 +539,19 @@ const Header: React.FC = memo(() => {
               <span>Loading events...</span>
             ) : (
               <>
-                <div className="event-dropdown preselect-dropdown" ref={preselectDropdownRef}>
-                  <button
-                    className="preselect-button"
-                    onClick={() => setIsPreselectModalOpen(true)}
-                    onTouchStart={() => setIsPreselectModalOpen(true)}
-                    disabled={liveEvents.length > 0 || upcomingEvents.length === 0}
-                    aria-label="Pre-Select Songs for Upcoming Events"
-                  >
-                    Pre-Select
-                  </button>
-                </div>
+                {upcomingEvents.length > 0 && (
+                  <div className="event-dropdown preselect-dropdown" ref={preselectDropdownRef}>
+                    <button
+                      className="preselect-button"
+                      onClick={() => setIsPreselectModalOpen(true)}
+                      onTouchStart={() => setIsPreselectModalOpen(true)}
+                      disabled={liveEvents.length > 0}
+                      aria-label="Pre-Select Songs for Upcoming Events"
+                    >
+                      Pre-Select
+                    </button>
+                  </div>
+                )}
                 <div className="event-dropdown join-event-dropdown" ref={eventDropdownRef}>
                   <button
                     className="check-in-button"

--- a/bnkaraoke.web/src/components/Modals.css
+++ b/bnkaraoke.web/src/components/Modals.css
@@ -124,6 +124,11 @@
     font-size: 0.7em;
   }
 
+  /* Ensure space on the right side to account for scrollbar width */
+  .song-card {
+    padding-right: calc(10px + 16px);
+  }
+
   .modal-overlay.mobile-modals .modal-content {
     height: 90vh;
     display: flex;

--- a/bnkaraoke.web/src/pages/ExploreSongs.css
+++ b/bnkaraoke.web/src/pages/ExploreSongs.css
@@ -412,6 +412,7 @@
   }
   .song-card {
     padding: 6px;
+    padding-right: calc(6px + 16px); /* Allow for scrollbar width on mobile */
   }
   .song-title {
     font-size: 0.9em;


### PR DESCRIPTION
## Summary
- prevent mobile song cards from touching the scrollbar by adding extra right padding
- hide mobile Pre-Select button when there are no upcoming events

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b89149ddc0832393aa55ea5f41040d