### PR TITLE
Add Workbox precaching service worker

### DIFF
--- a/bnkaraoke.web/package.json
+++ b/bnkaraoke.web/package.json
@@ -21,11 +21,14 @@
     "react-router-dom": "^7.5.0",
     "react-scripts": "5.0.1",
     "sanitize.css": "^13.0.0",
-    "web-vitals": "^4.2.4"
+    "web-vitals": "^4.2.4",
+    "workbox-core": "^6.6.0",
+    "workbox-precaching": "^6.6.0",
+    "workbox-routing": "^6.6.0"
   },
   "scripts": {
     "start": "cross-env HOST=0.0.0.0 react-scripts start",
-    "build": "react-scripts build",
+    "build": "react-scripts build && workbox injectManifest workbox-config.js",
     "build:dev": "cross-env NODE_ENV=development react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -62,7 +65,8 @@
     "cross-env": "^7.0.3",
     "eruda": "^3.4.1",
     "eslint-plugin-react-hooks": "^4.6.2",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "workbox-cli": "^6.6.0"
   },
   "proxy": "http://localhost:7290"
 }

--- a/bnkaraoke.web/src/service-worker.ts
+++ b/bnkaraoke.web/src/service-worker.ts
@@ -1,0 +1,10 @@
+import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+
+declare const self: ServiceWorkerGlobalScope & { __WB_MANIFEST: any };
+
+precacheAndRoute(self.__WB_MANIFEST);
+
+// Fallback to index.html for navigation requests
+const handler = createHandlerBoundToURL('/');
+registerRoute(({ request }) => request.mode === 'navigate', handler);

--- a/bnkaraoke.web/workbox-config.js
+++ b/bnkaraoke.web/workbox-config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  globDirectory: 'build/',
+  globPatterns: ['**/*.{js,css,html,png,svg,ico,json}'],
+  swSrc: 'src/service-worker.ts',
+  swDest: 'build/service-worker.js'
+};


### PR DESCRIPTION
## Summary
- add Workbox-based service worker with offline navigation fallback
- wire up Workbox injectManifest in build process

## Testing
- `npm install workbox-core --save` *(fails: 403 Forbidden)*
- `npm run build` *(fails: workbox: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b8b0693ecc8323a41e06246c668585