### PR TITLE
feat: add bass boost control for DJ console

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -37,6 +37,11 @@ namespace BNKaraoke.DJ.ViewModels
         private double? _fadeStartTimeSeconds;
         private double? _introMuteSeconds;
 
+        partial void OnBassBoostChanged(double value)
+        {
+            _videoPlayerWindow?.SetBassGain((float)value);
+        }
+
         public void SetWarningMessage(string message)
         {
             if (_isDisposing) return;
@@ -470,6 +475,7 @@ namespace BNKaraoke.DJ.ViewModels
                         _videoPlayerWindow = null;
                         return;
                     }
+                    _videoPlayerWindow.SetBassGain((float)BassBoost);
                     _videoPlayerWindow.SongEnded += VideoPlayerWindow_SongEnded;
                     _videoPlayerWindow.Closed += VideoPlayerWindow_Closed;
                     _videoPlayerWindow.MediaPlayer.PositionChanged += OnVLCPositionChanged;
@@ -660,6 +666,7 @@ namespace BNKaraoke.DJ.ViewModels
                         _videoPlayerWindow = null;
                         return;
                     }
+                    _videoPlayerWindow.SetBassGain((float)BassBoost);
                     _videoPlayerWindow.SongEnded += VideoPlayerWindow_SongEnded;
                     _videoPlayerWindow.Closed += VideoPlayerWindow_Closed;
                     _videoPlayerWindow.MediaPlayer.PositionChanged += OnVLCPositionChanged;
@@ -998,6 +1005,7 @@ namespace BNKaraoke.DJ.ViewModels
                         _videoPlayerWindow = null;
                         return;
                     }
+                    _videoPlayerWindow.SetBassGain((float)BassBoost);
                     _videoPlayerWindow.SongEnded += VideoPlayerWindow_SongEnded;
                     _videoPlayerWindow.Closed += VideoPlayerWindow_Closed;
                     _videoPlayerWindow.MediaPlayer.PositionChanged += OnVLCPositionChanged;

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -63,6 +63,7 @@ namespace BNKaraoke.DJ.ViewModels
         [ObservableProperty] private double _songPosition;
         [ObservableProperty] private TimeSpan _songDuration = TimeSpan.FromMinutes(4);
         [ObservableProperty] private string _stopRestartButtonColor = "#22d3ee"; // Default cyan
+        [ObservableProperty] private double _bassBoost; // Bass gain in dB (0-20)
 
         public ICommand? ViewSungSongsCommand { get; }
 

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -143,6 +143,8 @@
                             ValueChanged="Slider_ValueChanged"/>
                     <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding CurrentVideoPosition, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Left" Margin="5,15,0,5" Background="#80000000" Padding="2"/>
                     <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding SongDuration, StringFormat={}{0:m\\:ss}, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Right" Margin="0,15,5,5" Background="#80000000" Padding="2"/>
+                    <TextBlock Grid.Column="5" Grid.Row="1" Text="Bass Boost" FontSize="16" Foreground="White" VerticalAlignment="Center" Margin="5,0"/>
+                    <Slider Grid.Column="6" Grid.Row="1" Width="300" Minimum="0" Maximum="20" Value="{Binding BassBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="5,0"/>
                     <!-- Sung Songs -->
                     <Button Grid.Column="7" Grid.Row="0" Width="120" Height="40" Margin="5" Command="{Binding ViewSungSongsCommand}"
                             Content="View Sung Songs" Background="#22d3ee" Foreground="Black" FontWeight="Bold"/>

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -21,6 +21,7 @@ namespace BNKaraoke.DJ.Views
         private string? _currentVideoPath;
         private long _currentPosition;
         private DispatcherTimer? _hideVideoViewTimer;
+        private Equalizer? _equalizer;
 
         public event EventHandler? SongEnded;
         public new event EventHandler? Closed;
@@ -44,6 +45,24 @@ namespace BNKaraoke.DJ.Views
             SWP_NOCOPYBITS = 0x0100,
             SWP_NOOWNERZORDER = 0x0200,
             SWP_NOSENDCHANGING = 0x0400
+        }
+
+        public void SetBassGain(float gain)
+        {
+            try
+            {
+                if (MediaPlayer == null) return;
+                _equalizer ??= Equalizer.Create();
+                // Boost low-frequency bands
+                _equalizer.SetAmp(gain, 0);
+                _equalizer.SetAmp(gain, 1);
+                MediaPlayer.SetEqualizer(_equalizer);
+                Log.Information("[VIDEO PLAYER] Bass gain set to {Gain}dB", gain);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[VIDEO PLAYER] Failed to set bass gain: {Message}", ex.Message);
+            }
         }
 
         public VideoPlayerWindow()


### PR DESCRIPTION
## Summary
- add `BassBoost` slider to DJ screen for real-time low-end adjustment
- forward slider changes to video player and apply through LibVLC equalizer
- implement `SetBassGain` on video player to boost bass frequencies

## Testing
- ⚠️ `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` (command not found)
- ⚠️ `apt-get update` (403 errors; repository not signed)
- ⚠️ `apt-get install -y dotnet-sdk-8.0` (unable to locate package)
- ⚠️ `npm test` (missing script: test)


------
https://chatgpt.com/codex/tasks/task_e_68b906bb59dc832386c040704e74d4ff