### PR TITLE
Fix LibVLC equalizer initialization in DJ console

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -51,8 +51,8 @@ namespace BNKaraoke.DJ.Views
         {
             try
             {
-                if (MediaPlayer == null) return;
-                _equalizer ??= Equalizer.Create();
+                if (MediaPlayer == null || _libVLC == null) return;
+                _equalizer ??= Equalizer.Create(_libVLC);
                 // Boost low-frequency bands
                 _equalizer.SetAmp(gain, 0);
                 _equalizer.SetAmp(gain, 1);


### PR DESCRIPTION
## Summary
- create audio equalizer with LibVLC instance in VideoPlayerWindow
- guard against null LibVLC before applying bass gain

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90d5c9e50832384884b6b345c1807