### PR TITLE
Fix bass gain equalizer initialization

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -51,8 +51,8 @@ namespace BNKaraoke.DJ.Views
         {
             try
             {
-                if (MediaPlayer == null || _libVLC == null) return;
-                _equalizer ??= Equalizer.Create(_libVLC);
+                if (MediaPlayer == null) return;
+                _equalizer ??= new Equalizer();
                 // Boost low-frequency bands
                 _equalizer.SetAmp(gain, 0);
                 _equalizer.SetAmp(gain, 1);


### PR DESCRIPTION
## Summary
- use Equalizer's default constructor when applying bass gain

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90ff0f808832391bfd2dbe3b2251c