### PR TITLE
Display bass boost slider and skip zero fade values

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -711,11 +711,15 @@ namespace BNKaraoke.DJ.ViewModels
                     {
                         _baseVolume = 100 * Math.Pow(10, targetEntry.NormalizationGain.Value / 20.0);
                     }
-                    _fadeStartTimeSeconds = targetEntry.FadeStartTime;
-                    _introMuteSeconds = targetEntry.IntroMuteDuration;
+                    _fadeStartTimeSeconds = (targetEntry.FadeStartTime.HasValue && targetEntry.FadeStartTime.Value > 0)
+                        ? targetEntry.FadeStartTime.Value
+                        : null;
+                    _introMuteSeconds = (targetEntry.IntroMuteDuration.HasValue && targetEntry.IntroMuteDuration.Value > 0)
+                        ? targetEntry.IntroMuteDuration.Value
+                        : null;
                     if (_videoPlayerWindow.MediaPlayer != null)
                     {
-                        _videoPlayerWindow.MediaPlayer.Volume = (_introMuteSeconds.HasValue && _introMuteSeconds.Value > 0) ? 0 : (int)_baseVolume;
+                        _videoPlayerWindow.MediaPlayer.Volume = _introMuteSeconds.HasValue ? 0 : (int)_baseVolume;
                     }
                     Log.Information("[VIDEO PLAYER] Video playback started for QueueId={QueueId}, Path={Path}", targetEntry.QueueId, videoPath);
                 }

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -103,6 +103,7 @@
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="300"/>
                         <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto"/>
@@ -143,10 +144,12 @@
                             ValueChanged="Slider_ValueChanged"/>
                     <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding CurrentVideoPosition, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Left" Margin="5,15,0,5" Background="#80000000" Padding="2"/>
                     <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding SongDuration, StringFormat={}{0:m\\:ss}, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Right" Margin="0,15,5,5" Background="#80000000" Padding="2"/>
-                    <TextBlock Grid.Column="5" Grid.Row="1" Text="Bass Boost" FontSize="16" Foreground="White" VerticalAlignment="Center" Margin="5,0"/>
-                    <Slider Grid.Column="6" Grid.Row="1" Width="300" Minimum="0" Maximum="20" Value="{Binding BassBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Margin="5,0"/>
+                    <StackPanel Grid.Column="7" Grid.Row="0" Margin="5,0" HorizontalAlignment="Center">
+                        <Slider Orientation="Vertical" Height="60" Minimum="0" Maximum="20" Value="{Binding BassBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                        <TextBlock Text="Bass Boost" FontSize="16" Foreground="White" HorizontalAlignment="Center"/>
+                    </StackPanel>
                     <!-- Sung Songs -->
-                    <Button Grid.Column="7" Grid.Row="0" Width="120" Height="40" Margin="5" Command="{Binding ViewSungSongsCommand}"
+                    <Button Grid.Column="8" Grid.Row="0" Width="120" Height="40" Margin="5" Command="{Binding ViewSungSongsCommand}"
                             Content="View Sung Songs" Background="#22d3ee" Foreground="Black" FontWeight="Bold"/>
                 </Grid>
             </DockPanel>


### PR DESCRIPTION
## Summary
- show bass boost control as vertical slider beside seek bar
- ignore zero or missing fade/start mute times so videos play normally

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9131f16008323a18c77c773006065