### PR TITLE
Improve DJ console bass control and slider aesthetics

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -37,9 +37,9 @@ namespace BNKaraoke.DJ.ViewModels
         private double? _fadeStartTimeSeconds;
         private double? _introMuteSeconds;
 
-        partial void OnBassBoostChanged(double value)
+        partial void OnBassBoostChanged(int value)
         {
-            _videoPlayerWindow?.SetBassGain((float)value);
+            _videoPlayerWindow?.SetBassGain(value);
         }
 
         public void SetWarningMessage(string message)
@@ -475,7 +475,7 @@ namespace BNKaraoke.DJ.ViewModels
                         _videoPlayerWindow = null;
                         return;
                     }
-                    _videoPlayerWindow.SetBassGain((float)BassBoost);
+                    _videoPlayerWindow.SetBassGain(BassBoost);
                     _videoPlayerWindow.SongEnded += VideoPlayerWindow_SongEnded;
                     _videoPlayerWindow.Closed += VideoPlayerWindow_Closed;
                     _videoPlayerWindow.MediaPlayer.PositionChanged += OnVLCPositionChanged;
@@ -666,7 +666,7 @@ namespace BNKaraoke.DJ.ViewModels
                         _videoPlayerWindow = null;
                         return;
                     }
-                    _videoPlayerWindow.SetBassGain((float)BassBoost);
+                    _videoPlayerWindow.SetBassGain(BassBoost);
                     _videoPlayerWindow.SongEnded += VideoPlayerWindow_SongEnded;
                     _videoPlayerWindow.Closed += VideoPlayerWindow_Closed;
                     _videoPlayerWindow.MediaPlayer.PositionChanged += OnVLCPositionChanged;
@@ -1009,7 +1009,7 @@ namespace BNKaraoke.DJ.ViewModels
                         _videoPlayerWindow = null;
                         return;
                     }
-                    _videoPlayerWindow.SetBassGain((float)BassBoost);
+                    _videoPlayerWindow.SetBassGain(BassBoost);
                     _videoPlayerWindow.SongEnded += VideoPlayerWindow_SongEnded;
                     _videoPlayerWindow.Closed += VideoPlayerWindow_Closed;
                     _videoPlayerWindow.MediaPlayer.PositionChanged += OnVLCPositionChanged;

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -63,9 +63,11 @@ namespace BNKaraoke.DJ.ViewModels
         [ObservableProperty] private double _songPosition;
         [ObservableProperty] private TimeSpan _songDuration = TimeSpan.FromMinutes(4);
         [ObservableProperty] private string _stopRestartButtonColor = "#22d3ee"; // Default cyan
-        [ObservableProperty] private double _bassBoost; // Bass gain in dB (0-20)
+        [ObservableProperty] private int _bassBoost; // Bass gain in dB (0-20)
 
         public ICommand? ViewSungSongsCommand { get; }
+        public ICommand IncreaseBassBoostCommand { get; }
+        public ICommand DecreaseBassBoostCommand { get; }
 
         public DJScreenViewModel(VideoCacheService? videoCacheService = null)
         {
@@ -86,6 +88,8 @@ namespace BNKaraoke.DJ.ViewModels
                 _userSessionService.SessionChanged += UserSessionService_SessionChanged;
                 Log.Information("[DJSCREEN VM] Subscribed to SessionChanged event");
                 ViewSungSongsCommand = new RelayCommand(ExecuteViewSungSongs);
+                IncreaseBassBoostCommand = new RelayCommand(_ => BassBoost = Math.Min(20, BassBoost + 1));
+                DecreaseBassBoostCommand = new RelayCommand(_ => BassBoost = Math.Max(0, BassBoost - 1));
                 UpdateAuthenticationStateInitial();
                 LoadLiveEventsAsync().GetAwaiter().GetResult();
                 Log.Information("[DJSCREEN VM] Initialized UI state in constructor");

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -59,7 +59,7 @@
         <!-- Main Content -->
         <DockPanel>
             <!-- Control Area (Bottom) -->
-            <DockPanel DockPanel.Dock="Bottom" Height="120" Background="#1E3A5F" Margin="0,0,0,40">
+            <DockPanel DockPanel.Dock="Bottom" Height="120" Background="#1E3A5F" Margin="0">
                 <Border Width="80" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,10,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <Border.Style>
                         <Style TargetType="Border">
@@ -130,7 +130,7 @@
                             Content="{Binding AutoPlayButtonText, UpdateSourceTrigger=PropertyChanged}"
                             Background="#22d3ee" Foreground="Black" FontWeight="Bold"/>
                     <!-- Slider and Time Text -->
-                    <Slider x:Name="SeekSlider" Grid.Column="6" Grid.Row="0" Width="300"
+                    <Slider x:Name="SeekSlider" Grid.Column="6" Grid.Row="0" Width="300" Height="30"
                             Value="{Binding SongPosition, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                             Maximum="{Binding SongDuration.TotalSeconds, Mode=OneWay}"
                             Minimum="0"
@@ -141,15 +141,32 @@
                             Thumb.DragCompleted="Slider_DragCompleted"
                             PreviewMouseLeftButtonDown="Slider_PreviewMouseLeftButtonDown"
                             PreviewMouseLeftButtonUp="Slider_PreviewMouseLeftButtonUp"
-                            ValueChanged="Slider_ValueChanged"/>
+                            ValueChanged="Slider_ValueChanged"
+                            Background="#444">
+                        <Slider.Resources>
+                            <Style TargetType="Thumb">
+                                <Setter Property="Width" Value="15"/>
+                                <Setter Property="Height" Value="15"/>
+                                <Setter Property="Background" Value="#22d3ee"/>
+                                <Setter Property="BorderBrush" Value="White"/>
+                                <Setter Property="BorderThickness" Value="1"/>
+                            </Style>
+                        </Slider.Resources>
+                    </Slider>
                     <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding CurrentVideoPosition, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Left" Margin="5,15,0,5" Background="#80000000" Padding="2"/>
                     <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding SongDuration, StringFormat={}{0:m\\:ss}, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Right" Margin="0,15,5,5" Background="#80000000" Padding="2"/>
                     <Border Grid.Column="7" Grid.Row="0" Margin="5,0" HorizontalAlignment="Center"
                             BorderBrush="White" BorderThickness="1" Padding="5">
                         <StackPanel>
                             <TextBlock Text="B" FontSize="16" Foreground="White" HorizontalAlignment="Center"/>
-                            <Slider Orientation="Vertical" Height="100" Minimum="0" Maximum="20"
-                                    Value="{Binding BassBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5,0,0">
+                                <TextBox Width="40" TextAlignment="Center" IsReadOnly="True"
+                                         Text="{Binding BassBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                                <StackPanel Orientation="Vertical" Margin="5,0,0,0">
+                                    <Button Width="20" Height="20" Content="▲" Command="{Binding IncreaseBassBoostCommand}" Background="#22d3ee" Foreground="Black"/>
+                                    <Button Width="20" Height="20" Content="▼" Command="{Binding DecreaseBassBoostCommand}" Background="#22d3ee" Foreground="Black" Margin="0,5,0,0"/>
+                                </StackPanel>
+                            </StackPanel>
                         </StackPanel>
                     </Border>
                     <!-- Sung Songs -->


### PR DESCRIPTION
## Summary
- Replace bass boost slider with integer up/down control
- Restore original bottom spacing and restyle position slider thumb
- Add commands and int property for bass boost handling

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b06944f88323abc6cb139feb174d