### PR TITLE
Refine player UI controls in DJ console

### DIFF
--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -130,42 +130,51 @@
                             Content="{Binding AutoPlayButtonText, UpdateSourceTrigger=PropertyChanged}"
                             Background="#22d3ee" Foreground="Black" FontWeight="Bold"/>
                     <!-- Slider and Time Text -->
-                    <Slider x:Name="SeekSlider" Grid.Column="6" Grid.Row="0" Width="300" Height="30"
-                            Value="{Binding SongPosition, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                            Maximum="{Binding SongDuration.TotalSeconds, Mode=OneWay}"
-                            Minimum="0"
-                            IsEnabled="{Binding IsPlaying}"
-                            Margin="5,0"
-                            IsMoveToPointEnabled="True"
-                            Thumb.DragStarted="Slider_DragStarted"
-                            Thumb.DragCompleted="Slider_DragCompleted"
-                            PreviewMouseLeftButtonDown="Slider_PreviewMouseLeftButtonDown"
-                            PreviewMouseLeftButtonUp="Slider_PreviewMouseLeftButtonUp"
-                            ValueChanged="Slider_ValueChanged"
-                            Background="#444">
-                        <Slider.Resources>
-                            <Style TargetType="Thumb">
-                                <Setter Property="Width" Value="15"/>
-                                <Setter Property="Height" Value="15"/>
-                                <Setter Property="Background" Value="#22d3ee"/>
-                                <Setter Property="BorderBrush" Value="White"/>
-                                <Setter Property="BorderThickness" Value="1"/>
-                            </Style>
-                        </Slider.Resources>
-                    </Slider>
-                    <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding CurrentVideoPosition, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Left" Margin="5,15,0,5" Background="#80000000" Padding="2"/>
-                    <TextBlock Grid.Column="6" Grid.Row="0" Text="{Binding SongDuration, StringFormat={}{0:m\\:ss}, FallbackValue='--:--'}" FontSize="24" Foreground="White" HorizontalAlignment="Right" Margin="0,15,5,5" Background="#80000000" Padding="2"/>
+                    <Grid Grid.Column="6" Grid.Row="0" Width="300" Margin="5,0" VerticalAlignment="Center">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="60"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="60"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Grid.Column="0" Text="{Binding CurrentVideoPosition, FallbackValue='--:--'}"
+                                   FontSize="16" Foreground="White" VerticalAlignment="Center"
+                                   HorizontalAlignment="Center" Background="#80000000" Padding="2"/>
+                        <Slider x:Name="SeekSlider" Grid.Column="1" Height="30"
+                                Value="{Binding SongPosition, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                Maximum="{Binding SongDuration.TotalSeconds, Mode=OneWay}"
+                                Minimum="0"
+                                IsEnabled="{Binding IsPlaying}"
+                                IsMoveToPointEnabled="True"
+                                Thumb.DragStarted="Slider_DragStarted"
+                                Thumb.DragCompleted="Slider_DragCompleted"
+                                PreviewMouseLeftButtonDown="Slider_PreviewMouseLeftButtonDown"
+                                PreviewMouseLeftButtonUp="Slider_PreviewMouseLeftButtonUp"
+                                ValueChanged="Slider_ValueChanged"
+                                Background="#444">
+                            <Slider.Resources>
+                                <Style TargetType="Thumb">
+                                    <Setter Property="Width" Value="15"/>
+                                    <Setter Property="Height" Value="15"/>
+                                    <Setter Property="Background" Value="#22d3ee"/>
+                                    <Setter Property="BorderBrush" Value="White"/>
+                                    <Setter Property="BorderThickness" Value="1"/>
+                                </Style>
+                            </Slider.Resources>
+                        </Slider>
+                        <TextBlock Grid.Column="2" Text="{Binding SongDuration, StringFormat={}{0:m\\:ss}, FallbackValue='--:--'}"
+                                   FontSize="16" Foreground="White" VerticalAlignment="Center"
+                                   HorizontalAlignment="Center" Background="#80000000" Padding="2"/>
+                    </Grid>
                     <Border Grid.Column="7" Grid.Row="0" Margin="5,0" HorizontalAlignment="Center"
-                            BorderBrush="White" BorderThickness="1" Padding="5">
+                            BorderBrush="White" BorderThickness="1" Padding="5" Background="#1E3A5F">
                         <StackPanel>
-                            <TextBlock Text="B" FontSize="16" Foreground="White" HorizontalAlignment="Center"/>
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5,0,0">
-                                <TextBox Width="40" TextAlignment="Center" IsReadOnly="True"
-                                         Text="{Binding BassBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-                                <StackPanel Orientation="Vertical" Margin="5,0,0,0">
-                                    <Button Width="20" Height="20" Content="▲" Command="{Binding IncreaseBassBoostCommand}" Background="#22d3ee" Foreground="Black"/>
-                                    <Button Width="20" Height="20" Content="▼" Command="{Binding DecreaseBassBoostCommand}" Background="#22d3ee" Foreground="Black" Margin="0,5,0,0"/>
-                                </StackPanel>
+                            <TextBlock Text="Bass" FontSize="14" Foreground="White" HorizontalAlignment="Center"/>
+                            <StackPanel Orientation="Horizontal" Margin="0,5,0,0" VerticalAlignment="Center">
+                                <Slider Width="80" Minimum="0" Maximum="20"
+                                        Value="{Binding BassBoost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                        TickFrequency="1" IsSnapToTickEnabled="True" Background="#444"/>
+                                <TextBlock Text="{Binding BassBoost}" FontSize="14" Foreground="White"
+                                           Width="30" HorizontalAlignment="Center" Margin="5,0,0,0" TextAlignment="Center"/>
                             </StackPanel>
                         </StackPanel>
                     </Border>


### PR DESCRIPTION
## Summary
- clean up seek bar layout by moving time displays to the sides
- restyle bass boost as slider with numeric display

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb19752a7c8323b108f3b8097682b3