### PR TITLE
Expand queue layout and anchor player on DJ console

### DIFF
--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -57,9 +57,13 @@
             </DockPanel>
         </Grid>
         <!-- Main Content -->
-        <DockPanel>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
             <!-- Control Area (Bottom) -->
-            <DockPanel DockPanel.Dock="Bottom" Height="120" Background="#1E3A5F" Margin="0">
+            <DockPanel Grid.Row="1" Height="120" Background="#1E3A5F" Margin="0">
                 <Border Width="80" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,10,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center">
                     <Border.Style>
                         <Style TargetType="Border">
@@ -184,7 +188,7 @@
                 </Grid>
             </DockPanel>
             <!-- Grid for Queue and Singers -->
-            <Grid>
+            <Grid Grid.Row="0">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="3*"/>
                     <ColumnDefinition Width="1*"/>
@@ -416,6 +420,6 @@
                     </DockPanel>
                 </Border>
             </Grid>
-        </DockPanel>
+        </Grid>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- Restructure DJScreen layout using a two-row grid so queue and singer panels fill available space
- Anchor the control panel at the bottom to push the player further down

## Testing
- ⚠️ `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(missing `dotnet` CLI)*
- ⚠️ `apt-get update` *(403 errors preventing package installation)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1b4e23808323a330175a3669d3c1