### PR TITLE
Fix mismatched closing tag in DJ screen

### DIFF
--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -415,6 +415,5 @@
                     </DockPanel>
                 </Border>
             </Grid>
-        </Grid>
     </DockPanel>
 </Window>


### PR DESCRIPTION
## Summary
- fix root layout closing tag in DJScreen to resolve build error

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb22a11c883238a2a306e511dfca0