### PR TITLE
Align SM and FO boxes and fix bass boost command warnings

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -66,8 +66,8 @@ namespace BNKaraoke.DJ.ViewModels
         [ObservableProperty] private int _bassBoost; // Bass gain in dB (0-20)
 
         public ICommand? ViewSungSongsCommand { get; }
-        public ICommand IncreaseBassBoostCommand { get; }
-        public ICommand DecreaseBassBoostCommand { get; }
+        public ICommand IncreaseBassBoostCommand { get; } = null!;
+        public ICommand DecreaseBassBoostCommand { get; } = null!;
 
         public DJScreenViewModel(VideoCacheService? videoCacheService = null)
         {

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -78,14 +78,14 @@
                     </Border.Style>
                     <TextBlock Text="{Binding TimeRemaining}" FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                 </Border>
-                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center"
+                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,10,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Top"
                         Visibility="{Binding PlayingQueueEntry.FadeStartTime, Converter={StaticResource PositiveVisibilityConverter}}">
                     <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
                         <Run Text="FO: "/>
                         <Run Text="{Binding PlayingQueueEntry.FadeStartTime, Converter={StaticResource SecondsToTimeConverter}}"/>
                     </TextBlock>
                 </Border>
-                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center"
+                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,10,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Top"
                         Visibility="{Binding PlayingQueueEntry.IntroMuteDuration, Converter={StaticResource PositiveVisibilityConverter}}">
                     <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
                         <Run Text="SM: "/>


### PR DESCRIPTION
## Summary
- Align SM and FO boxes vertically with playback controls
- Initialize bass boost commands to avoid nullable warnings

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj -p:EnableWindowsTargeting=true` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbcd94bcac832389fd06c5cf3478d5