### PR TITLE
Prevent DJ console from covering taskbar

### DIFF
--- a/BNKaraoke.DJ/App.xaml.cs
+++ b/BNKaraoke.DJ/App.xaml.cs
@@ -92,7 +92,7 @@ namespace BNKaraoke.DJ
             base.OnStartup(e);
 
             var userSessionService = UserSessionService.Instance;
-            var mainWindow = new DJScreen { WindowState = settingsService.Settings.MaximizedOnStart ? WindowState.Maximized : WindowState.Normal };
+            var mainWindow = new DJScreen();
             Log.Information("[APP START] Checking session: IsAuthenticated={IsAuthenticated}", userSessionService.IsAuthenticated);
             mainWindow.Show();
 

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -6,7 +6,7 @@
         xmlns:services="clr-namespace:BNKaraoke.DJ.Services"
         xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
         xmlns:behaviors="clr-namespace:BNKaraoke.DJ.Behaviors"
-        WindowState="Maximized" Title="DJ Console"
+        WindowState="Normal" Title="DJ Console"
         WindowStyle="None" ResizeMode="NoResize"
         Loaded="Window_Loaded">
     <Window.Resources>

--- a/BNKaraoke.DJ/Views/DJScreen.xaml.cs
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml.cs
@@ -40,6 +40,16 @@ namespace BNKaraoke.DJ.Views
                     Close();
                     return;
                 }
+
+                var settings = SettingsService.Instance.Settings;
+                if (settings.MaximizedOnStart)
+                {
+                    var workArea = SystemParameters.WorkArea;
+                    Top = workArea.Top;
+                    Left = workArea.Left;
+                    Width = workArea.Width;
+                    Height = workArea.Height;
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- Resize DJ console window to the working area so Windows taskbar remains visible
- Stop startup from forcing the DJ window into full-screen mode

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4892acf48323bca56872f3c697cf