### PR TITLE
Reduce DJ console bottom padding

### DIFF
--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -58,8 +58,8 @@
             </DockPanel>
         </Grid>
         <!-- Control Area (Bottom) -->
-        <DockPanel DockPanel.Dock="Bottom" Height="120" Background="#1E3A5F" Margin="0">
-            <Border Width="80" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,0,10,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center">
+        <DockPanel DockPanel.Dock="Bottom" Height="80" Background="#1E3A5F" Margin="0">
+            <Border Width="80" Height="40" BorderBrush="White" BorderThickness="1" Margin="5,0,5,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Center">
                 <Border.Style>
                     <Style TargetType="Border">
                         <Setter Property="Background" Value="Green"/>
@@ -78,21 +78,21 @@
                     </Border.Style>
                     <TextBlock Text="{Binding TimeRemaining}" FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                 </Border>
-                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,10,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Top"
+                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="5,5,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Top"
                         Visibility="{Binding PlayingQueueEntry.FadeStartTime, Converter={StaticResource PositiveVisibilityConverter}}">
                     <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
                         <Run Text="FO: "/>
                         <Run Text="{Binding PlayingQueueEntry.FadeStartTime, Converter={StaticResource SecondsToTimeConverter}}"/>
                     </TextBlock>
                 </Border>
-                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="10,10,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Top"
+                <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="5,5,0,0" Padding="5" DockPanel.Dock="Right" VerticalAlignment="Top"
                         Visibility="{Binding PlayingQueueEntry.IntroMuteDuration, Converter={StaticResource PositiveVisibilityConverter}}">
                     <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
                         <Run Text="SM: "/>
                         <Run Text="{Binding PlayingQueueEntry.IntroMuteDuration, Converter={StaticResource SecondsToTimeConverter}}"/>
                     </TextBlock>
                 </Border>
-                <Grid Margin="10">
+                <Grid Margin="5">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="Auto"/>


### PR DESCRIPTION
## Summary
- Shrink DJ console control area and margins to free vertical space for queues and singers

## Testing
- `dotnet test BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc602816f88323b656f1ceb9e22294