### PR TITLE
Keep DJ timer visible when idle

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -138,7 +138,7 @@ namespace BNKaraoke.DJ.ViewModels
                     else
                     {
                         TimeRemainingSeconds = 0;
-                        TimeRemaining = "0:00";
+                        TimeRemaining = "--:--";
                         CurrentVideoPosition = "--:--";
                         SongPosition = 0;
                         _lastPosition = 0;
@@ -399,7 +399,7 @@ namespace BNKaraoke.DJ.ViewModels
                 _lastPosition = 0;
                 CurrentVideoPosition = "--:--";
                 TimeRemainingSeconds = 0;
-                TimeRemaining = "0:00";
+                TimeRemaining = "--:--";
                 StopRestartButtonColor = "#22d3ee";
                 PlayingQueueEntry = null;
                 SongDuration = TimeSpan.Zero;
@@ -694,7 +694,7 @@ namespace BNKaraoke.DJ.ViewModels
                     _lastPosition = 0;
                     CurrentVideoPosition = "0:00";
                     TimeRemainingSeconds = 0;
-                    TimeRemaining = "0:00";
+                    TimeRemaining = "--:--";
                     StopRestartButtonColor = "#22d3ee";
                     NotifyAllProperties();
                     Log.Information("[DJSCREEN] UI updated for new song: QueueId={QueueId}, SongTitle={SongTitle}", targetEntry.QueueId, targetEntry.SongTitle);
@@ -1037,7 +1037,7 @@ namespace BNKaraoke.DJ.ViewModels
                     _lastPosition = 0;
                     CurrentVideoPosition = "0:00";
                     TimeRemainingSeconds = 0;
-                    TimeRemaining = "0:00";
+                    TimeRemaining = "--:--";
                     StopRestartButtonColor = "#22d3ee";
                     NotifyAllProperties();
                     Log.Information("[DJSCREEN] UI updated for new song: QueueId={QueueId}, SongTitle={SongTitle}", targetEntry.QueueId, targetEntry.SongTitle);

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -302,7 +302,7 @@ namespace BNKaraoke.DJ.ViewModels
                     SongPosition = 0;
                     CurrentVideoPosition = "--:--";
                     TimeRemainingSeconds = 0;
-                    TimeRemaining = "0:00";
+                    TimeRemaining = "--:--";
                     OnPropertyChanged(nameof(SongPosition));
                     OnPropertyChanged(nameof(CurrentVideoPosition));
                     OnPropertyChanged(nameof(TimeRemaining));
@@ -329,7 +329,7 @@ namespace BNKaraoke.DJ.ViewModels
                 SongPosition = 0;
                 CurrentVideoPosition = "--:--";
                 TimeRemainingSeconds = 0;
-                TimeRemaining = "0:00";
+                TimeRemaining = "--:--";
                 OnPropertyChanged(nameof(SongPosition));
                 OnPropertyChanged(nameof(CurrentVideoPosition));
                 OnPropertyChanged(nameof(TimeRemaining));

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -54,7 +54,7 @@ namespace BNKaraoke.DJ.ViewModels
         [ObservableProperty] private bool _isAutoPlayEnabled = true;
         [ObservableProperty] private string _autoPlayButtonText = "Auto Play: On";
         [ObservableProperty] private string _currentVideoPosition = "--:--";
-        [ObservableProperty] private string _timeRemaining = "0:00";
+        [ObservableProperty] private string _timeRemaining = "--:--";
         [ObservableProperty] private int _timeRemainingSeconds;
         [ObservableProperty] private DateTime? _warningExpirationTime;
         [ObservableProperty] private bool _isVideoPaused;
@@ -403,7 +403,7 @@ namespace BNKaraoke.DJ.ViewModels
                     SongPosition = 0;
                     CurrentVideoPosition = "--:--";
                     TimeRemainingSeconds = 0;
-                    TimeRemaining = "0:00";
+                    TimeRemaining = "--:--";
                     StopRestartButtonColor = "#22d3ee";
                     OnPropertyChanged(nameof(PlayingQueueEntry));
                     OnPropertyChanged(nameof(IsPlaying));

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -77,17 +77,25 @@
                 <Border Width="80" Height="40" BorderBrush="White" BorderThickness="1" Margin="5,0,5,0" Padding="5" VerticalAlignment="Center">
                     <Border.Style>
                         <Style TargetType="Border">
-                            <Setter Property="Background" Value="Green"/>
+                            <Setter Property="Background" Value="#1E3A5F"/>
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding TimeRemainingSeconds, Converter={StaticResource TimeRemainingConverter}, ConverterParameter=30}" Value="True">
+                                <DataTrigger Binding="{Binding IsPlaying}" Value="True">
+                                    <Setter Property="Background" Value="Green"/>
+                                </DataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding IsPlaying}" Value="True"/>
+                                        <Condition Binding="{Binding TimeRemainingSeconds, Converter={StaticResource TimeRemainingConverter}, ConverterParameter=30}" Value="True"/>
+                                    </MultiDataTrigger.Conditions>
                                     <Setter Property="Background" Value="#FFA500"/>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding TimeRemainingSeconds, Converter={StaticResource TimeRemainingConverter}, ConverterParameter=10}" Value="True">
+                                </MultiDataTrigger>
+                                <MultiDataTrigger>
+                                    <MultiDataTrigger.Conditions>
+                                        <Condition Binding="{Binding IsPlaying}" Value="True"/>
+                                        <Condition Binding="{Binding TimeRemainingSeconds, Converter={StaticResource TimeRemainingConverter}, ConverterParameter=10}" Value="True"/>
+                                    </MultiDataTrigger.Conditions>
                                     <Setter Property="Background" Value="Red"/>
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding IsPlaying}" Value="False">
-                                    <Setter Property="Visibility" Value="Collapsed"/>
-                                </DataTrigger>
+                                </MultiDataTrigger>
                             </Style.Triggers>
                         </Style>
                     </Border.Style>


### PR DESCRIPTION
## Summary
- keep countdown timer on screen and adjust coloring logic
- show "--:--" placeholder when not playing

## Testing
- `dotnet build BNKaraoke.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc69f73b4c83239e467480984fd6f3