### PR TITLE
Specify .NET 8 SDK for DJ console publish

### DIFF
--- a/Scripts/Publish-DJConsoleClickOnce.ps1
+++ b/Scripts/Publish-DJConsoleClickOnce.ps1
@@ -12,6 +12,10 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+# Show which .NET SDK is being used for troubleshooting
+$dotnetVersion = dotnet --version
+Write-Host "Using .NET SDK version $dotnetVersion"
+
 # Validate required paths
 foreach ($path in @($ProjectPath, $IconPath)) {
     if (-not (Test-Path $path)) {

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
- log the .NET SDK version used in the ClickOnce publish script for easier troubleshooting
- add global.json to pin builds to the .NET 8 SDK and avoid newer preview SDK regressions

## Testing
- `dotnet --version` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bc913aef9c83239b2b638eab426422