### PR TITLE
Fix runtime target and enable single-file publish

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -9,6 +9,11 @@
     <Nullable>enable</Nullable>
     <Version>1.0.0</Version>
     <!-- Added for DJ Console 1.0 -->
+    <!-- Target a specific Windows runtime and publish as a self-contained single file -->
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>true</PublishSingleFile>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Scripts/Publish-DJConsoleClickOnce.ps1
+++ b/Scripts/Publish-DJConsoleClickOnce.ps1
@@ -52,6 +52,10 @@ $newRevision = $oldVersion.Revision + 1
 $propertyGroup.Version = "{0}.{1}.{2}.{3}" -f $oldVersion.Major, $oldVersion.Minor, $oldVersion.Build, $newRevision
 $csproj.Save($ProjectPath)
 
+# Restore the project for the desired runtime so the assets file contains
+# the correct target before publishing.
+dotnet restore $ProjectPath -r win-x64 | Out-Null
+
 $publishArgs = @(
     '-c', 'Release',
     '-r', 'win-x64',
@@ -65,7 +69,8 @@ $publishArgs = @(
     '/p:UpdateMode=Foreground',
     '/p:UpdateRequired=true',
     '/p:CheckForUpdate=true',
-    "/p:ApplicationIcon=$IconPath"
+    "/p:ApplicationIcon=$IconPath",
+    '/p:PublishSingleFile=true'
 )
 
 Write-Host "Publishing version $($propertyGroup.Version) to $PublishDir"


### PR DESCRIPTION
## Summary
- target win-x64 and bundle self-contained single-file executable
- ensure ClickOnce publish script restores with runtime and requests single-file output

## Testing
- `dotnet restore BNKaraoke.DJ/BNKaraoke.DJ.csproj -r win-x64` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc9446614883238580d2f5c6e8e430