### PR TITLE
Fix DJ publish script and bump version baseline

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -7,7 +7,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\app.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
-    <Version>1.0.0</Version>
+    <Version>1.5.0.0</Version>
     <!-- Added for DJ Console 1.0 -->
     <!-- Target a specific Windows runtime and publish as a self-contained single file -->
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>


### PR DESCRIPTION
## Summary
- update BNKaraoke DJ project to start at version 1.5.0.0
- simplify DJ ClickOnce publish script and remove duplicate ApplicationIcon arg to avoid MSB3094
- ensure script sets baseline version 1.5.0.0 and increments revision each run

## Testing
- `dotnet --version` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd09e782a883238b001cfbd79d692e