### PR TITLE
fix: resolve publishing copy error

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationManifest>app.manifest</ApplicationManifest>
-    <ApplicationIcon>Assets\app.ico</ApplicationIcon>
+    <ApplicationIcon>Assets/app.ico</ApplicationIcon>
     <Nullable>enable</Nullable>
     <Version>1.5.0.0</Version>
     <!-- Added for DJ Console 1.0 -->
@@ -17,13 +17,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Assets\TwoSingerMnt.png" />
-    <None Remove="Assets\gear3.png" />
-    <None Remove="Assets\bnk-qr-code.png" />
-    <None Remove="Tools\yt-dlp.exe" />
-    <None Remove="Tools\ffmpeg.exe" />
-    <None Remove="Tools\libvlc.dll" />
-    <None Remove="Tools\libvlccore.dll" />
+    <None Remove="Assets/TwoSingerMnt.png" />
+    <None Remove="Assets/gear3.png" />
+    <None Remove="Assets/bnk-qr-code.png" />
+    <None Remove="Tools/yt-dlp.exe" />
+    <None Remove="Tools/ffmpeg.exe" />
+    <None Remove="Tools/libvlc.dll" />
+    <None Remove="Tools/libvlccore.dll" />
   </ItemGroup>
 
   <ItemGroup>
@@ -51,13 +51,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Resource Include="Assets\TwoSingerMnt.png">
+    <Resource Include="Assets/TwoSingerMnt.png">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>
-    <Resource Include="Assets\gear3.png">
+    <Resource Include="Assets/gear3.png">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>
-    <Resource Include="Assets\bnk-qr-code.png">
+    <Resource Include="Assets/bnk-qr-code.png">
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
     </Resource>
   </ItemGroup>

--- a/Scripts/Publish-DJConsoleClickOnce.ps1
+++ b/Scripts/Publish-DJConsoleClickOnce.ps1
@@ -36,7 +36,7 @@ New-Item -ItemType Directory -Path $StagingDir -Force | Out-Null
 # "DestinationFiles refers to 2 item(s), and SourceFiles refers to 1 item(s)".
 $projectDir = Split-Path $ProjectPath -Parent
 Write-Host "Cleaning project $ProjectPath"
-dotnet clean $ProjectPath -c Release
+dotnet clean $ProjectPath -c Release -r win-x64
 Remove-Item -Path (Join-Path $projectDir 'bin') -Recurse -Force -ErrorAction SilentlyContinue
 Remove-Item -Path (Join-Path $projectDir 'obj') -Recurse -Force -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
## Summary
- normalize resource paths in BNKaraoke.DJ project file
- clean runtime-specific output before publishing DJ console

## Testing
- `pwsh Scripts/Publish-DJConsoleClickOnce.ps1 -ProjectPath "BNKaraoke.DJ/BNKaraoke.DJ.csproj" -PublishDir ./tmp_publish -InstallUrl "https://www.example.com/" -StagingDir ./tmp_staging -VersionFile ./tmp_version.txt` *(fails: command not found: pwsh)*
- `dotnet publish BNKaraoke.DJ/BNKaraoke.DJ.csproj -c Release -r win-x64 --self-contained true /p:PublishProtocol=ClickOnce /p:PublishDir=tmp_staging /p:InstallUrl=https://example.com/ /p:ApplicationVersion=1.0.0.1 /p:ApplicationRevision=1 /p:Version=1.0.0.1 /p:UpdateEnabled=true /p:UpdateMode=Foreground /p:UpdateRequired=true /p:CheckForUpdate=true /p:PublishSingleFile=true` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc09e4770832386e6f17d9ceef8d8