### PR TITLE
chore: update DJ ClickOnce deployment

### DIFF
--- a/BNKaraoke.DJ.Package/BNKaraoke.DJ.Package.csproj
+++ b/BNKaraoke.DJ.Package/BNKaraoke.DJ.Package.csproj
@@ -1,46 +1,29 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <!-- Make sure OutputType is WinExe, not Library -->
     <UseWPF>true</UseWPF>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <ApplicationManifest>Package.appxmanifest</ApplicationManifest>
-    <WindowsPackageType>MSIX</WindowsPackageType>
-
-    <!-- MSIX Package Configuration -->
-    <PackageCertificateThumbprint>YourCertificateThumbprint</PackageCertificateThumbprint>
-    <!-- Optional if signed -->
-    <IdentityName>YourAppName</IdentityName>
-    <PackageDisplayName>YourAppDisplayName</PackageDisplayName>
-    <PackagePublisher>CN=YourPublisher</PackagePublisher>
-    <PackagePublisherDisplayName>Your Publisher Display Name</PackagePublisherDisplayName>
-
-    <PublishProfile>Properties\PublishProfiles\win10-x64.pubxml</PublishProfile>
     <Nullable>enable</Nullable>
+    <SelfContained>false</SelfContained>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <UpdateEnabled>true</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>true</UpdateRequired>
+    <GenerateDeploymentManifest>true</GenerateDeploymentManifest>
+    <GenerateApplicationManifest>true</GenerateApplicationManifest>
+    <SignManifests>true</SignManifests>
+    <InstallUrl>https://www.bnkaraoke.com/DJConsole/</InstallUrl>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\BNKaraoke.DJ\BNKaraoke.DJ.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="..\BNKaraoke.DJ\Assets\*.png">
+    <Content Include="..\BNKaraoke.DJ\bin\Release\net8.0-windows\win-x64\BNKaraoke.DJ.exe">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Assets\%(Filename)%(Extension)</Link>
+      <IncludeInClickOnce>true</IncludeInClickOnce>
     </Content>
-    <Content Include="..\BNKaraoke.DJ\Tools\*.*">
+    <Content Include="..\BNKaraoke.DJ\bin\Release\net8.0-windows\win-x64\Tools\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Tools\%(Filename)%(Extension)</Link>
-    </Content>
-    <Content Include="..\BNKaraoke.DJ\Scripts\**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>Scripts\%(RecursiveDir)%(Filename)%(Extension)</Link>
-    </Content>
-    <Content Include="..\BNKaraoke.DJ\settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>settings.json</Link>
+      <IncludeInClickOnce>true</IncludeInClickOnce>
     </Content>
   </ItemGroup>
 

--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -14,6 +14,10 @@
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <PublishProtocol>ClickOnce</PublishProtocol>
+    <UpdateEnabled>true</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateRequired>true</UpdateRequired>
   </PropertyGroup>
 
   <ItemGroup>
@@ -66,18 +70,22 @@
       <Content Include="Tools/yt-dlp.exe">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <IncludeInClickOnce>true</IncludeInClickOnce>
       </Content>
       <Content Include="Tools/ffmpeg.exe">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <IncludeInClickOnce>true</IncludeInClickOnce>
       </Content>
       <Content Include="Tools/libvlc.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <IncludeInClickOnce>true</IncludeInClickOnce>
       </Content>
       <Content Include="Tools/libvlccore.dll">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+        <IncludeInClickOnce>true</IncludeInClickOnce>
       </Content>
     </ItemGroup>
 

--- a/Scripts/Publish-DJConsoleClickOnce.ps1
+++ b/Scripts/Publish-DJConsoleClickOnce.ps1
@@ -80,17 +80,10 @@ $publishArgs = @(
     '-c', 'Release',
     '-r', 'win-x64',
     '--self-contained', 'true',
-    '/p:PublishProtocol=ClickOnce',
     "/p:PublishDir=$StagingDir",
     "/p:InstallUrl=$InstallUrl",
     "/p:ApplicationVersion=$newVersion",
-    "/p:ApplicationRevision=$newRevision",
-    "/p:Version=$newVersion",
-    '/p:UpdateEnabled=true',
-    '/p:UpdateMode=Foreground',
-    '/p:UpdateRequired=true',
-    '/p:CheckForUpdate=true',
-    '/p:PublishSingleFile=true'
+    "/p:ApplicationRevision=$newRevision"
 )
 
 Write-Host "Publishing version $newVersion to staging directory $StagingDir"


### PR DESCRIPTION
## Summary
- streamline ClickOnce publish script
- align BNKaraoke.DJ project with ClickOnce requirements
- configure BNKaraoke.DJ.Package to package published output

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj -c Release -r win-x64` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `pwsh Scripts/Publish-DJConsoleClickOnce.ps1 -PublishDir ./tmp_publish -InstallUrl http://localhost/ -VersionFile ./tmp_publish/version.txt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc92b24c083239f85f1750ead4959