### PR TITLE
Fix build by removing hardcoded LibVLC plugin references

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -66,43 +66,9 @@
     </Resource>
   </ItemGroup>
 
-  <!-- Trim unused LibVLC assets to reduce ClickOnce manifest size -->
-  <ItemGroup>
-    <!-- Remove 32-bit binaries and Lua scripts -->
-    <None Remove="libvlc/win-x86/**" />
-    <None Remove="libvlc/win-x64/lua/**" />
-    <!-- Drop unneeded plugin categories -->
-    <None Remove="libvlc/win-x64/plugins/access/**" />
-    <None Remove="libvlc/win-x64/plugins/gui/**" />
-  </ItemGroup>
-
-  <!-- Explicitly include the minimal set of plugins required for playback -->
-  <ItemGroup>
-    <Content Include="libvlc/win-x64/plugins/codec/libavcodec_plugin.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInClickOnce>true</IncludeInClickOnce>
-    </Content>
-    <Content Include="libvlc/win-x64/plugins/demux/libmp4_plugin.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInClickOnce>true</IncludeInClickOnce>
-    </Content>
-    <Content Include="libvlc/win-x64/plugins/demux/libogg_plugin.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInClickOnce>true</IncludeInClickOnce>
-    </Content>
-    <Content Include="libvlc/win-x64/plugins/audio_filter/libkaraoke_plugin.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInClickOnce>true</IncludeInClickOnce>
-    </Content>
-    <Content Include="libvlc/win-x64/plugins/audio_output/libmmdevice_plugin.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInClickOnce>true</IncludeInClickOnce>
-    </Content>
-    <Content Include="libvlc/win-x64/plugins/video_output/libdirect3d11_plugin.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInClickOnce>true</IncludeInClickOnce>
-    </Content>
-  </ItemGroup>
+  <!-- Rely on VideoLAN.LibVLC.Windows package to supply necessary plugins.
+       Explicit plugin references have been removed to avoid build errors
+       when the libvlc directory is not present in the project tree. -->
 
     <ItemGroup>
       <Content Include="Tools/yt-dlp.exe">


### PR DESCRIPTION
## Summary
- remove hardcoded LibVLC plugin content items from BNKaraoke.DJ so build no longer fails when libvlc directory is absent

## Testing
- `dotnet restore BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: `dotnet: command not found`)*
- `apt-get update` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68be106e87488323acbdbb94b55764c9