### PR TITLE
fix: handle ClickOnce tool items correctly

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -24,8 +24,6 @@
     <None Remove="Assets/TwoSingerMnt.png" />
     <None Remove="Assets/gear3.png" />
     <None Remove="Assets/bnk-qr-code.png" />
-    <None Remove="Tools/yt-dlp.exe" />
-    <None Remove="Tools/ffmpeg.exe" />
   </ItemGroup>
 
   <ItemGroup>
@@ -68,24 +66,22 @@
        Explicit plugin references have been removed to avoid build errors
        when the libvlc directory is not present in the project tree. -->
 
-    <ItemGroup>
-      <!-- Ensure each tool is published with a single, explicit destination path
-           to avoid MSB3094 "DestinationFiles" mismatches during ClickOnce
-           publishing. -->
-      <Content Include="Tools/yt-dlp.exe">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        <IncludeInClickOnce>true</IncludeInClickOnce>
-        <TargetPath>Tools\yt-dlp.exe</TargetPath>
-      </Content>
-      <Content Include="Tools/ffmpeg.exe">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-        <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-        <IncludeInClickOnce>true</IncludeInClickOnce>
-        <TargetPath>Tools\ffmpeg.exe</TargetPath>
-      </Content>
-    </ItemGroup>
 
+  <ItemGroup>
+    <!-- Ensure required tools are published correctly without triggering
+         MSB3094 "DestinationFiles" mismatches. Updating the existing items
+         avoids duplicate metadata entries. -->
+    <None Update="Tools/yt-dlp.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <IncludeInClickOnce>true</IncludeInClickOnce>
+    </None>
+    <None Update="Tools/ffmpeg.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+      <IncludeInClickOnce>true</IncludeInClickOnce>
+    </None>
+  </ItemGroup>
 </Project>

--- a/Scripts/Publish-DJConsoleClickOnce.ps1
+++ b/Scripts/Publish-DJConsoleClickOnce.ps1
@@ -85,6 +85,7 @@ if ($LASTEXITCODE -ne 0) {
 $publishArgs = @(
     '-c', 'Release',
     '-r', 'win-x64',
+    '--no-restore',
     '--self-contained', 'true',
     "/p:PublishDir=$StagingDir",
     "/p:InstallUrl=$InstallUrl",


### PR DESCRIPTION
## Summary
- ensure yt-dlp and ffmpeg tools are updated in the project instead of re-added so ClickOnce publish doesn't miscount files
- avoid extra restore when publishing the DJ console

## Testing
- `powershell -NoLogo -NoProfile -File Scripts/Publish-DJConsoleClickOnce.ps1 -ProjectPath BNKaraoke.DJ/BNKaraoke.DJ.csproj -PublishDir /tmp/publish -InstallUrl https://example.com/ -VersionFile /tmp/version.txt` *(fails: command not found: powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68be539dca148323af8e68ad45176c60