### PR TITLE
Ensure main assembly is included in ClickOnce publish

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -84,4 +84,14 @@
       <IncludeInClickOnce>true</IncludeInClickOnce>
     </None>
   </ItemGroup>
+
+  <!-- Ensure the main assembly is always included when publishing via ClickOnce -->
+  <Target Name="AddMainAssemblyToPublish" BeforeTargets="_CopyFilesToPublishFolder">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(TargetPath)">
+        <TargetPath>$(TargetFileName)</TargetPath>
+        <SourcePath>$(TargetPath)</SourcePath>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
## Summary
- add MSBuild target to always include BNKaraoke.DJ.dll during ClickOnce publish

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be5c044bac8323845c89182d3a7ec1