### PR TITLE
fix: prevent duplicate main assembly during publish

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -88,7 +88,7 @@
   <!-- Ensure the main assembly is always included when publishing via ClickOnce -->
   <Target Name="AddMainAssemblyToPublish" AfterTargets="ComputeFilesToPublish">
     <ItemGroup>
-      <ResolvedFileToPublish Include="$(TargetPath)">
+      <ResolvedFileToPublish Update="$(TargetPath)">
         <TargetPath>$(TargetFileName)</TargetPath>
         <SourcePath>$(TargetPath)</SourcePath>
         <!-- Ensure the relative path is set so the file copies with the correct name -->


### PR DESCRIPTION
## Summary
- update custom target to adjust existing ResolvedFileToPublish instead of adding duplicate, preventing multiple main DLLs during ClickOnce publish

## Testing
- `dotnet publish BNKaraoke.DJ/BNKaraoke.DJ.csproj -r win-x64 -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7122716883239bc06723d7322d55