### PR TITLE
Add Windows default fallback option for audio output

### DIFF
--- a/BNKaraoke.DJ/Models/AudioDeviceConstants.cs
+++ b/BNKaraoke.DJ/Models/AudioDeviceConstants.cs
@@ -1,0 +1,8 @@
+namespace BNKaraoke.DJ.Models
+{
+    public static class AudioDeviceConstants
+    {
+        public const string WindowsDefaultAudioDeviceId = "windows-default-output";
+        public const string WindowsDefaultDisplayName = "Windows Default Output";
+    }
+}

--- a/BNKaraoke.DJ/Models/DjSettings.cs
+++ b/BNKaraoke.DJ/Models/DjSettings.cs
@@ -7,7 +7,7 @@ namespace BNKaraoke.DJ.Models
         public List<string> AvailableApiUrls { get; set; } = new List<string> { "http://localhost:7290", "https://bnkaraoke.com:7290" };
         public string ApiUrl { get; set; } = "http://localhost:7290";
         public string DefaultDJName { get; set; } = "DJ Ted";
-        public string PreferredAudioDevice { get; set; } = "Focusrite USB Audio";
+        public string PreferredAudioDevice { get; set; } = AudioDeviceConstants.WindowsDefaultAudioDeviceId;
         public string KaraokeVideoDevice { get; set; } = @"\\.\DISPLAY1";
         public bool EnableVideoCaching { get; set; } = true;
         public string VideoCachePath { get; set; } = @"C:\BNKaraoke\Cache\";

--- a/BNKaraoke.DJ/Views/SettingsWindow.xaml
+++ b/BNKaraoke.DJ/Views/SettingsWindow.xaml
@@ -46,7 +46,7 @@
             <GroupBox Grid.Row="2" Header="Audio and Video Settings" Foreground="White" Margin="0,5">
                 <StackPanel Margin="5">
                     <TextBlock Text="Preferred Audio Device" Foreground="White" Margin="0,0,0,5"/>
-                    <ComboBox ItemsSource="{Binding AvailableAudioDevices}" SelectedItem="{Binding PreferredAudioDevice}" DisplayMemberPath="FriendlyName" Width="300" HorizontalAlignment="Left" Margin="0,0,0,5"/>
+                    <ComboBox ItemsSource="{Binding AvailableAudioDevices}" SelectedItem="{Binding PreferredAudioDevice}" DisplayMemberPath="DisplayName" Width="300" HorizontalAlignment="Left" Margin="0,0,0,5"/>
                     <TextBlock Text="Karaoke Video Device" Foreground="White" Margin="0,0,0,5"/>
                     <ComboBox ItemsSource="{Binding AvailableVideoDevices}" SelectedItem="{Binding KaraokeVideoDevice}" DisplayMemberPath="DisplayName" Width="300" HorizontalAlignment="Left" Margin="0,0,0,5"/>
                     <CheckBox Content="Enable Video Caching" IsChecked="{Binding EnableVideoCaching}" Foreground="White" Margin="0,0,0,5"/>


### PR DESCRIPTION
## Summary
- introduce shared audio device constants and default preferred device configuration
- ensure the settings UI always offers a Windows default output option and maps legacy saved values
- update VLC media creation to honor the selected audio device while falling back to Windows default when appropriate

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d833df96b883238932a0b2b7b0ea12