### PR TITLE
Restore per-song adjustments on restart

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Player.cs
@@ -864,6 +864,25 @@ namespace BNKaraoke.DJ.ViewModels
                 }
                 else
                 {
+                    if (_videoPlayerWindow.MediaPlayer != null)
+                    {
+                        _baseVolume = 100;
+                        if (PlayingQueueEntry.NormalizationGain.HasValue)
+                        {
+                            _baseVolume = 100 * Math.Pow(10, PlayingQueueEntry.NormalizationGain.Value / 20.0);
+                        }
+
+                        _fadeStartTimeSeconds = (PlayingQueueEntry.FadeStartTime.HasValue && PlayingQueueEntry.FadeStartTime.Value > 0)
+                            ? PlayingQueueEntry.FadeStartTime.Value
+                            : null;
+
+                        _introMuteSeconds = (PlayingQueueEntry.IntroMuteDuration.HasValue && PlayingQueueEntry.IntroMuteDuration.Value > 0)
+                            ? PlayingQueueEntry.IntroMuteDuration.Value
+                            : null;
+
+                        _videoPlayerWindow.MediaPlayer.Volume = _introMuteSeconds.HasValue ? 0 : (int)_baseVolume;
+                    }
+
                     _videoPlayerWindow.RestartVideo();
                     if (_updateTimer == null)
                     {


### PR DESCRIPTION
## Summary
- restore the base volume, fade, and intro mute metadata from the playing queue entry before restarting playback
- reapply the computed volume so intro mute and normalization remain effective after a restart

## Testing
- dotnet build BNKaraoke.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8386291948323bf577091c26ac82b