### PR TITLE
Fix ClickOnce publish duplicate main assembly entry

### DIFF
--- a/BNKaraoke.DJ/BNKaraoke.DJ.csproj
+++ b/BNKaraoke.DJ/BNKaraoke.DJ.csproj
@@ -86,9 +86,11 @@
   </ItemGroup>
 
   <!-- Ensure the main assembly is always included when publishing via ClickOnce -->
-  <Target Name="AddMainAssemblyToPublish" AfterTargets="ComputeFilesToPublish">
+  <Target Name="UpdateMainAssemblyPublishMetadata" AfterTargets="ComputeFilesToPublish">
     <ItemGroup>
-      <ResolvedFileToPublish Update="$(TargetPath)">
+      <!-- Update the existing main assembly entry instead of adding a duplicate -->
+      <ResolvedFileToPublish Update="@(ResolvedFileToPublish)"
+                             Condition="'%(ResolvedFileToPublish.Identity)' == '$(TargetPath)'">
         <TargetPath>$(TargetFileName)</TargetPath>
         <SourcePath>$(TargetPath)</SourcePath>
         <!-- Ensure the relative path is set so the file copies with the correct name -->


### PR DESCRIPTION
## Summary
- prevent ClickOnce publish from adding duplicate main assembly entries by updating the existing ResolvedFileToPublish item

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d85ad8efbc83238487f9a7ce941d0f