### PR TITLE
Improve playback stability and add DJ console controls

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -63,6 +63,7 @@ namespace BNKaraoke.DJ.ViewModels
         [ObservableProperty] private double _songPosition;
         [ObservableProperty] private TimeSpan _songDuration = TimeSpan.FromMinutes(4);
         [ObservableProperty] private string _stopRestartButtonColor = "#22d3ee"; // Default cyan
+        [ObservableProperty] private string _normalizationDisplay = "0.0 dB";
         [ObservableProperty] private int _bassBoost; // Bass gain in dB (0-20)
 
         public ICommand? ViewSungSongsCommand { get; }

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -38,28 +38,38 @@
             <Image Source="pack://application:,,,/Assets/TwoSingerMnt.png" Width="48" Margin="10,0" Stretch="Uniform" Grid.Column="0"/>
             <TextBlock Text="BNKaraoke.com DJ App" FontSize="28" FontWeight="Bold" Foreground="White"
                        VerticalAlignment="Center" HorizontalAlignment="Center" Grid.Column="1"/>
-            <DockPanel Grid.Column="2" Margin="0,0,0,0" HorizontalAlignment="Right">
+            <StackPanel Grid.Column="2" Margin="0" HorizontalAlignment="Right" Orientation="Horizontal">
                 <Button x:Name="CacheButton" Width="100" Height="40" Margin="5,0,0,0" Background="Blue"
-                        Content="Cache" Command="{Binding OpenCacheManagerCommand}" DockPanel.Dock="Right"/>
+                        Content="Cache" Command="{Binding OpenCacheManagerCommand}"/>
                 <Button x:Name="SettingsButton" Width="40" Height="40" Margin="5,0,0,0" Background="Blue"
-                        Command="{Binding OpenSettingsCommand}" DockPanel.Dock="Right">
+                        Command="{Binding OpenSettingsCommand}">
                     <Image Source="pack://application:,,,/Assets/gear3.png" Width="24" Height="24"/>
                 </Button>
-                <Button x:Name="LoginLogoutButton" Width="100" Height="40" Margin="5,0,5,0"
+                <Button x:Name="LoginLogoutButton" Width="100" Height="40" Margin="5,0,0,0"
                         Content="{Binding LoginLogoutButtonText, UpdateSourceTrigger=PropertyChanged}"
                         Background="{Binding LoginLogoutButtonColor, UpdateSourceTrigger=PropertyChanged}"
-                        Foreground="White" FontWeight="Bold" Command="{Binding LoginLogoutCommand}" DockPanel.Dock="Right"/>
+                        Foreground="White" FontWeight="Bold" Command="{Binding LoginLogoutCommand}"/>
+                <Button x:Name="ViewSungSongsHeaderButton" Width="160" Height="40" Margin="5,0,0,0"
+                        Content="View Sung Songs" Background="#22d3ee" Foreground="Black" FontWeight="Bold"
+                        Command="{Binding ViewSungSongsCommand}"/>
                 <Button x:Name="JoinEventButton" Width="200" Height="40" Margin="5,0,5,0"
                         Content="{Binding JoinEventButtonText, UpdateSourceTrigger=PropertyChanged}"
                         Background="{Binding JoinEventButtonColor, UpdateSourceTrigger=PropertyChanged}"
                         IsEnabled="{Binding IsJoinEventButtonEnabled, UpdateSourceTrigger=PropertyChanged}"
                         Visibility="{Binding IsJoinEventButtonVisible, Converter={StaticResource BooleanToVisibilityConverter}, UpdateSourceTrigger=PropertyChanged}"
                         Command="{Binding JoinLiveEventCommand}"/>
-            </DockPanel>
+            </StackPanel>
         </Grid>
         <!-- Control Area (Bottom) -->
         <DockPanel DockPanel.Dock="Bottom" Height="80" Background="#1E3A5F" Margin="0">
             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center">
+                <Border Width="130" Height="40" BorderBrush="White" BorderThickness="1" Margin="5,0,0,0" Padding="5"
+                        Background="#1E3A5F">
+                    <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
+                        <Run Text="LV: "/>
+                        <Run Text="{Binding NormalizationDisplay}"/>
+                    </TextBlock>
+                </Border>
                 <Border Width="100" Height="40" BorderBrush="White" BorderThickness="1" Margin="5,0,0,0" Padding="5"
                         Visibility="Visible">
                     <TextBlock FontSize="18" FontWeight="Bold" Foreground="White" VerticalAlignment="Center" HorizontalAlignment="Center">
@@ -188,8 +198,24 @@
                         </StackPanel>
                     </Border>
                     <!-- Sung Songs -->
-                    <Button Grid.Column="8" Grid.Row="0" Width="120" Height="40" Margin="5" Command="{Binding ViewSungSongsCommand}"
-                            Content="View Sung Songs" Background="#22d3ee" Foreground="Black" FontWeight="Bold"/>
+                    <Button Grid.Column="8" Grid.Row="0" Width="60" Height="40" Margin="5" Command="{Binding TriggerManualFadeOutCommand}"
+                            IsEnabled="{Binding IsPlaying}">
+                        <Button.Style>
+                            <Style TargetType="Button">
+                                <Setter Property="Background" Value="#374151"/>
+                                <Setter Property="Foreground" Value="White"/>
+                                <Setter Property="FontWeight" Value="Bold"/>
+                                <Setter Property="BorderBrush" Value="White"/>
+                                <Setter Property="BorderThickness" Value="1"/>
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsPlaying}" Value="True">
+                                        <Setter Property="Background" Value="#DC2626"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Button.Style>
+                        <TextBlock Text="FO" FontSize="18" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Button>
                 </Grid>
         </DockPanel>
 

--- a/BNKaraoke.DJ/Views/SongDetailsWindow.xaml
+++ b/BNKaraoke.DJ/Views/SongDetailsWindow.xaml
@@ -4,50 +4,95 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Width="650" Height="400" Background="#2D2D2D" WindowStyle="SingleBorderWindow" ResizeMode="NoResize"
         WindowStartupLocation="CenterScreen">
+  <Window.Resources>
+    <Style x:Key="DetailsValueTextBoxStyle" TargetType="TextBox">
+      <Setter Property="IsReadOnly" Value="True"/>
+      <Setter Property="Background" Value="#1F2937"/>
+      <Setter Property="BorderThickness" Value="0"/>
+      <Setter Property="Foreground" Value="White"/>
+      <Setter Property="FontSize" Value="16"/>
+      <Setter Property="Padding" Value="4"/>
+      <Setter Property="Margin" Value="0,0,0,5"/>
+      <Setter Property="VerticalContentAlignment" Value="Center"/>
+      <Setter Property="ContextMenu">
+        <Setter.Value>
+          <ContextMenu>
+            <MenuItem Command="ApplicationCommands.Copy" Header="Copy"/>
+          </ContextMenu>
+        </Setter.Value>
+      </Setter>
+    </Style>
+  </Window.Resources>
   <Grid Margin="20">
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
       <RowDefinition Height="Auto"/>
     </Grid.RowDefinitions>
-    <TextBlock Grid.Row="0" Text="{Binding SelectedQueueEntry.SongTitle, FallbackValue='N/A'}"
+    <TextBlock Grid.Row="0" Text="{Binding SongTitle, FallbackValue='N/A'}"
                FontSize="20" Foreground="#22d3ee" Margin="0,0,0,10" TextAlignment="Center"/>
-    <StackPanel Grid.Row="1" Orientation="Vertical">
-      <TextBlock Foreground="#0000FF" FontSize="16" FontWeight="Bold" Margin="0,0,0,5">
-        <Run Text="Artist: "/>
-        <Run Text="{Binding SelectedQueueEntry.SongArtist, FallbackValue='N/A'}" Foreground="#FFFFFF" FontSize="16" FontWeight="Normal"/>
-      </TextBlock>
-      <TextBlock Foreground="#0000FF" FontSize="16" FontWeight="Bold" Margin="0,0,0,5">
-        <Run Text="Requestor: "/>
-        <Run Text="{Binding SelectedQueueEntry.RequestorDisplayName, FallbackValue='N/A'}" Foreground="#FFFFFF" FontSize="16" FontWeight="Normal"/>
-      </TextBlock>
-      <TextBlock Foreground="#0000FF" FontSize="16" FontWeight="Bold" Margin="0,0,0,5">
-        <Run Text="Video Length: "/>
-        <Run Text="{Binding SelectedQueueEntry.VideoLength, FallbackValue='N/A'}" Foreground="#FFFFFF" FontSize="16" FontWeight="Normal"/>
-      </TextBlock>
-      <TextBlock Foreground="#0000FF" FontSize="16" FontWeight="Bold" Margin="0,0,0,5">
-        <Run Text="Genre: "/>
-        <Run Text="{Binding Genre, FallbackValue='N/A'}" Foreground="#FFFFFF" FontSize="16" FontWeight="Normal"/>
-      </TextBlock>
-      <TextBlock Foreground="#0000FF" FontSize="16" FontWeight="Bold" Margin="0,0,0,5">
-        <Run Text="Decade: "/>
-        <Run Text="{Binding Decade, FallbackValue='N/A'}" Foreground="#FFFFFF" FontSize="16" FontWeight="Normal"/>
-      </TextBlock>
-      <TextBlock Foreground="#0000FF" FontSize="16" FontWeight="Bold" Margin="0,0,0,5">
-        <Run Text="YouTube URL: "/>
-        <Run Text="{Binding YouTubeUrl, FallbackValue='N/A'}" Foreground="#FFFFFF" FontSize="16" FontWeight="Normal">
-          <Run.ContextMenu>
-            <ContextMenu>
-              <MenuItem Header="Copy to Clipboard" Command="{Binding CopyYouTubeUrlCommand}"/>
-            </ContextMenu>
-          </Run.ContextMenu>
-        </Run>
-      </TextBlock>
-      <TextBlock Foreground="#0000FF" FontSize="16" FontWeight="Bold" Margin="0,0,0,5">
-        <Run Text="Cached: "/>
-        <Run Text="{Binding SelectedQueueEntry.IsVideoCached, StringFormat='{}{0}', FallbackValue='N/A'}" Foreground="#FFFFFF" FontSize="16" FontWeight="Normal"/>
-      </TextBlock>
-    </StackPanel>
+    <Grid Grid.Row="1" Margin="0,0,0,10">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="170"/>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+        <RowDefinition Height="Auto"/>
+      </Grid.RowDefinitions>
+      <TextBlock Grid.Row="0" Grid.Column="0" Text="Song ID:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding SongId}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="1" Grid.Column="0" Text="Title:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SongTitle}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="2" Grid.Column="0" Text="Artist:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="2" Grid.Column="1" Text="{Binding SongArtist}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="3" Grid.Column="0" Text="Genre:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="3" Grid.Column="1" Text="{Binding Genre}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="4" Grid.Column="0" Text="Status:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="4" Grid.Column="1" Text="{Binding Status}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="5" Grid.Column="0" Text="Mood:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="5" Grid.Column="1" Text="{Binding Mood}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="6" Grid.Column="0" Text="Server Cached:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="6" Grid.Column="1" Text="{Binding ServerCached}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="7" Grid.Column="0" Text="Mature Content:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="7" Grid.Column="1" Text="{Binding MatureContent}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="8" Grid.Column="0" Text="Gain Value:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="8" Grid.Column="1" Text="{Binding GainValue}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="9" Grid.Column="0" Text="FO Start:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="9" Grid.Column="1" Text="{Binding FadeOutStart}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="10" Grid.Column="0" Text="Intro Mute:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,5"/>
+      <TextBox Grid.Row="10" Grid.Column="1" Text="{Binding IntroMute}" Style="{StaticResource DetailsValueTextBoxStyle}"/>
+
+      <TextBlock Grid.Row="11" Grid.Column="0" Text="Song URL:" Foreground="#60A5FA" FontSize="16" FontWeight="Bold" Margin="0,0,10,0"/>
+      <TextBox Grid.Row="11" Grid.Column="1" Text="{Binding SongUrl}" Style="{StaticResource DetailsValueTextBoxStyle}">
+        <TextBox.ContextMenu>
+          <ContextMenu>
+            <MenuItem Command="ApplicationCommands.Copy" Header="Copy"/>
+            <MenuItem Header="Copy URL" Command="{Binding CopySongUrlCommand}"/>
+          </ContextMenu>
+        </TextBox.ContextMenu>
+      </TextBox>
+    </Grid>
     <Button Grid.Row="2" Content="Close" Width="100" Height="40" HorizontalAlignment="Center"
             Background="#22d3ee" Foreground="Black" Margin="0,10,0,0"
             Command="{Binding CloseCommand}" CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=Window}}"/>


### PR DESCRIPTION
## Summary
- harden the LibVLC media player lifecycle to prevent silent playback and to publish media length updates
- update DJ playback logic to honour normalization, intro mute, and fade metadata while adding a manual fade-out control with UI feedback
- refresh the DJ console header/layout and expand the song details modal with normalization, caching, and timing metadata

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da85966ccc83239c1ad2573466258a