### PR TITLE
Fix LibVLC audio output enumeration usage

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -202,7 +202,7 @@ namespace BNKaraoke.DJ.Views
                 try
                 {
                     var module = _settingsService.Settings.AudioOutputModule ?? "mmdevice";
-                    using var outputs = _libVLC.AudioOutputList();
+                    using var outputs = new AudioOutputList(_libVLC);
                     var moduleInfo = outputs?.FirstOrDefault(o => string.Equals(o.Name, module, StringComparison.OrdinalIgnoreCase));
 
                     if (moduleInfo == null)


### PR DESCRIPTION
## Summary
- instantiate `AudioOutputList` directly when enumerating LibVLC outputs to match the current API surface

## Testing
- not run (dotnet SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dab278b07083238700b17a2ffe01fd