### PR TITLE
Enhance song metadata display in DJ console

### DIFF
--- a/bnkaraoke.web/src/components/SongDetailsModal.css
+++ b/bnkaraoke.web/src/components/SongDetailsModal.css
@@ -17,13 +17,12 @@
 }
 .modal-content.song-details-modal {
   background: #fff !important;
-  padding: 20px;
-  border-radius: 8px;
-  width: 90%;
-  max-width: 600px;
-  max-height: 80vh;
+  padding: 24px;
+  border-radius: 12px;
+  width: min(95%, 760px);
+  max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.25);
   touch-action: pan-y;
   color: #1e293b !important;
 }
@@ -36,6 +35,10 @@
   font-size: 1em;
   margin: 5px 0;
   color: #1e293b !important;
+}
+.modal-text a {
+  color: #2563eb;
+  word-break: break-all;
 }
 .modal-text strong {
   color: #1e3a8a !important;
@@ -89,7 +92,10 @@
   color: white;
 }
 .song-details {
-  margin-bottom: 20px;
+  margin-bottom: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px 24px;
 }
 .song-actions {
   display: flex;
@@ -142,8 +148,8 @@
     padding: 15px;
   }
   .modal-content.song-details-modal {
-    width: 80%;
-    padding: 15px;
+    width: 90%;
+    padding: 18px;
     max-height: 85vh;
     touch-action: pan-y;
   }
@@ -183,14 +189,18 @@
     padding: 5px; /* Reduced padding */
   }
   .modal-content.song-details-modal {
-    width: 85%; /* Reduced width */
-    padding: 5px; /* Match header padding */
+    width: 95%; /* Reduced width */
+    padding: 12px; /* Match header padding */
     max-height: 90vh;
     touch-action: pan-y;
     margin-left: auto;
     margin-right: auto; /* Add right padding via margin */
     display: flex;
     flex-direction: column;
+  }
+  .song-details {
+    grid-template-columns: 1fr;
+    gap: 8px 0;
   }
   .modal-title {
     font-size: 1.3em;

--- a/bnkaraoke.web/src/types.ts
+++ b/bnkaraoke.web/src/types.ts
@@ -142,7 +142,17 @@ export const normalizeSong = (rawInput: unknown): Song => {
   const spotifyId = sanitizeString(coalesce(raw.spotifyId, source.SpotifyId));
   if (spotifyId !== undefined) normalized.spotifyId = spotifyId;
 
-  const youtubeUrl = sanitizeString(coalesce(raw.youTubeUrl, source.YouTubeUrl, source.youtubeUrl));
+  const youtubeUrl = sanitizeString(
+    coalesce(
+      raw.youTubeUrl,
+      source.YouTubeUrl,
+      source.youtubeUrl,
+      source.YouTubeURL,
+      source.youtubeURL,
+      source.songUrl,
+      source.SongUrl
+    )
+  );
   if (youtubeUrl !== undefined) normalized.youTubeUrl = youtubeUrl;
 
   const status = sanitizeString(coalesce(raw.status, source.Status));
@@ -151,7 +161,9 @@ export const normalizeSong = (rawInput: unknown): Song => {
   const approvedBy = sanitizeString(coalesce(raw.approvedBy, source.ApprovedBy));
   if (approvedBy !== undefined) normalized.approvedBy = approvedBy;
 
-  const mature = toBoolean(coalesce(raw.mature, source.Mature));
+  const mature = toBoolean(
+    coalesce(raw.mature, source.Mature, source.MatureContent, source.isMature, source.IsMature)
+  );
   if (mature !== undefined) normalized.mature = mature;
 
   const requestDate = sanitizeString(coalesce(raw.requestDate, source.RequestDate));
@@ -172,13 +184,43 @@ export const normalizeSong = (rawInput: unknown): Song => {
   const valence = toNumber(coalesce(raw.valence, source.Valence));
   if (valence !== undefined) normalized.valence = valence;
 
-  const normalizationGain = toNullableNumber(coalesce(raw.normalizationGain, source.NormalizationGain));
+  const normalizationGain = toNullableNumber(
+    coalesce(
+      raw.normalizationGain,
+      source.NormalizationGain,
+      source.normalizationGain,
+      source.NormilizationGain,
+      source.normilizationGain
+    )
+  );
   if (normalizationGain !== undefined) normalized.normalizationGain = normalizationGain;
 
-  const fadeStartTime = toNullableNumber(coalesce(raw.fadeStartTime, source.FadeStartTime));
+  const fadeStartTime = toNullableNumber(
+    coalesce(
+      raw.fadeStartTime,
+      source.FadeStartTime,
+      source.fadeStartTime,
+      source.fadeStart,
+      source.FadeStart,
+      source.FadeOutStart,
+      source.fadeOutStart,
+      source.FOStart,
+      source.foStart
+    )
+  );
   if (fadeStartTime !== undefined) normalized.fadeStartTime = fadeStartTime;
 
-  const introMuteDuration = toNullableNumber(coalesce(raw.introMuteDuration, source.IntroMuteDuration));
+  const introMuteDuration = toNullableNumber(
+    coalesce(
+      raw.introMuteDuration,
+      source.IntroMuteDuration,
+      source.introMuteDuration,
+      source.IntroMute,
+      source.introMute,
+      source.IntroMuteSeconds,
+      source.introMuteSeconds
+    )
+  );
   if (introMuteDuration !== undefined) normalized.introMuteDuration = introMuteDuration;
 
   const cached = toBoolean(coalesce(raw.cached, source.Cached));


### PR DESCRIPTION
## Summary
- normalize additional API field names so mature content, gain, fade, intro mute, and YouTube URL values populate reliably in the song details modal
- expand the song details modal layout to a wider, responsive grid to surface the extended metadata cleanly and improve URL readability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacc6623ac8323841e44fa7ea996ac