### PR TITLE
Resize DJ song details window

### DIFF
--- a/BNKaraoke.DJ/Views/SongDetailsWindow.xaml
+++ b/BNKaraoke.DJ/Views/SongDetailsWindow.xaml
@@ -2,7 +2,9 @@
 <Window x:Class="BNKaraoke.DJ.Views.SongDetailsWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Width="650" Height="400" Background="#2D2D2D" WindowStyle="SingleBorderWindow" ResizeMode="NoResize"
+        xmlns:win="clr-namespace:System.Windows;assembly=PresentationFramework"
+        Width="650" Height="600" MinHeight="400" MaxHeight="{x:Static win:SystemParameters.WorkAreaHeight}" Background="#2D2D2D"
+        WindowStyle="SingleBorderWindow" ResizeMode="CanResize"
         WindowStartupLocation="CenterScreen">
   <Window.Resources>
     <Style x:Key="DetailsValueTextBoxStyle" TargetType="TextBox">


### PR DESCRIPTION
## Summary
- revert the unintended SongDetailsModal styling changes in the web project
- enlarge the BNKaraoke.DJ song details window and allow resizing so more fields fit without scrolling
- cap the window height to the desktop work area to avoid overflowing smaller displays

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dad63c511c8323872388f966776cfc