### PR TITLE
Add exit button and shutdown workflow to DJ console

### DIFF
--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -67,6 +67,9 @@
                         Content="{Binding LoginLogoutButtonText, UpdateSourceTrigger=PropertyChanged}"
                         Background="{Binding LoginLogoutButtonColor, UpdateSourceTrigger=PropertyChanged}"
                         Foreground="White" FontWeight="Bold" Command="{Binding LoginLogoutCommand}"/>
+                <Button x:Name="ExitButton" Width="80" Height="40" Margin="5,0,10,0"
+                        Content="Exit" Background="#FF0000" Foreground="Black" FontWeight="Bold"
+                        Command="{Binding ExitApplicationCommand}"/>
             </StackPanel>
         </Grid>
         <!-- Control Area (Bottom) -->


### PR DESCRIPTION
## Summary
- add a dedicated Exit button to the BNKaraoke.DJ header and bind it to a new command
- share logout/leave-event helpers so the exit workflow can stop playback, shows, events, and sessions before shutdown
- ensure the exit workflow closes all application windows after cleaning up timers and services

## Testing
- dotnet build BNKaraoke.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dade9ba0908323861eedc0967bb88c