### PR TITLE
Fix mobile search modals overlapping with header

### DIFF
--- a/bnkaraoke.web/src/components/Header.tsx
+++ b/bnkaraoke.web/src/components/Header.tsx
@@ -58,6 +58,39 @@ const Header: React.FC = memo(() => {
     return () => mediaQuery.removeEventListener("change", handleResize);
   }, [checkedIn, currentEvent, liveEvents, upcomingEvents, location.pathname]);
 
+  useEffect(() => {
+    const headerElement = document.querySelector<HTMLDivElement>(".header-container");
+
+    if (!headerElement) {
+      document.documentElement.style.setProperty("--app-header-height", "0px");
+      return;
+    }
+
+    const updateHeaderHeight = () => {
+      const height = headerElement.getBoundingClientRect().height;
+      document.documentElement.style.setProperty("--app-header-height", `${Math.ceil(height)}px`);
+    };
+
+    updateHeaderHeight();
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(() => updateHeaderHeight());
+      resizeObserver.observe(headerElement);
+    }
+
+    window.addEventListener("resize", updateHeaderHeight);
+    window.addEventListener("orientationchange", updateHeaderHeight);
+
+    return () => {
+      window.removeEventListener("resize", updateHeaderHeight);
+      window.removeEventListener("orientationchange", updateHeaderHeight);
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+    };
+  }, [isMobile, checkedIn, currentEvent, liveEvents, upcomingEvents]);
+
   const adminRoles = ["Application Manager", "Karaoke DJ", "Song Manager", "User Manager", "Queue Manager", "Event Manager"];
   const hasAdminRole = roles.some((role) => adminRoles.includes(role));
   const adminRoutes = useMemo(() => [

--- a/bnkaraoke.web/src/components/Modals.css
+++ b/bnkaraoke.web/src/components/Modals.css
@@ -13,6 +13,13 @@
   touch-action: pan-y;
 }
 
+.modal-overlay[class*="mobile-"] {
+  align-items: flex-start;
+  padding-top: calc(var(--app-header-height, 0px) + env(safe-area-inset-top, 0px));
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  box-sizing: border-box;
+}
+
 .modal-content {
   background: #fff;
   padding: 20px;
@@ -129,24 +136,30 @@
     padding-right: calc(10px + 16px);
   }
 
-  .modal-overlay.mobile-modals .modal-content {
-    height: 90vh;
+  .modal-overlay[class*="mobile-"] .modal-content {
     display: flex;
     flex-direction: column;
     padding: 10px;
+    height: auto;
+    max-height: calc(100vh - var(--app-header-height, 0px) - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+    box-sizing: border-box;
   }
 
-  .modal-overlay.mobile-modals .modal-body {
+  .modal-overlay.mobile-modals .modal-body,
+  .modal-overlay.mobile-spotify-modal .modal-body {
     flex: 1;
     overflow-y: auto;
   }
 
-  .modal-overlay.mobile-modals .modal-actions {
+  .modal-overlay.mobile-modals .modal-actions,
+  .modal-overlay.mobile-spotify-modal .modal-actions {
     margin-top: auto;
   }
 
   .modal-overlay.mobile-modals .action-button,
-  .modal-overlay.mobile-modals .modal-cancel {
+  .modal-overlay.mobile-modals .modal-cancel,
+  .modal-overlay.mobile-spotify-modal .action-button,
+  .modal-overlay.mobile-spotify-modal .modal-cancel {
     min-height: 44px;
   }
 }

--- a/bnkaraoke.web/src/index.css
+++ b/bnkaraoke.web/src/index.css
@@ -1,4 +1,8 @@
 /* src\index.css */
+:root {
+  --app-header-height: 0px;
+}
+
 html {
   -webkit-text-size-adjust: 100%;
 }


### PR DESCRIPTION
## Summary
- expose the dynamic header height as a CSS variable so downstream components can offset their layout on mobile
- update mobile modal styling to respect the header height and safe-area insets so search results are no longer hidden

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daec7201888323ba1423e13724c148