### PR TITLE
Expand Manage Events layout height

### DIFF
--- a/bnkaraoke.web/src/pages/EventManagement.css
+++ b/bnkaraoke.web/src/pages/EventManagement.css
@@ -88,6 +88,8 @@
   border-radius: 12px;
   padding: 20px 24px;
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
 }
 
 .card-container {
@@ -98,6 +100,7 @@
   width: 100%;
   margin: 0 auto;
   min-height: 0;
+  height: 100%;
 }
 
 .event-table-card {
@@ -116,6 +119,7 @@
   flex-direction: column;
   gap: 20px;
   overflow: hidden;
+  height: 100%;
 }
 
 .event-list {


### PR DESCRIPTION
## Summary
- ensure the Manage Events card and its container stretch to fill the available viewport height so the section uses the full page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbca04343483239b863ba9de3efb7a