### PR TITLE
Increase Manage Events grid visibility

### DIFF
--- a/bnkaraoke.web/src/pages/EventManagement.css
+++ b/bnkaraoke.web/src/pages/EventManagement.css
@@ -1,7 +1,7 @@
 .event-management-container {
   min-height: 100vh;
   height: 100vh;
-  padding: 24px;
+  padding: 24px 24px 32px;
   background: linear-gradient(to bottom, #1e3a8a, #3b82f6);
   color: #f8fafc;
   display: flex;
@@ -42,7 +42,7 @@
 }
 
 .action-button {
-  padding: 10px 18px;
+  padding: 9px 16px;
   background: #22d3ee;
   color: #052c57;
   border: none;
@@ -88,6 +88,8 @@
   border-radius: 12px;
   padding: 20px 24px;
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
 }
 
 .card-container {
@@ -98,6 +100,7 @@
   width: 100%;
   margin: 0 auto;
   min-height: 0;
+  height: 100%;
 }
 
 .event-table-card {
@@ -111,11 +114,12 @@
   width: 100%;
   max-width: 1400px;
   flex: 1;
-  min-height: 0;
+  min-height: clamp(520px, calc(100vh - 220px), 100%);
   display: flex;
   flex-direction: column;
   gap: 20px;
   overflow: hidden;
+  height: 100%;
 }
 
 .event-list {
@@ -124,11 +128,14 @@
   padding: 0;
   display: grid;
   gap: 18px;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+  grid-auto-rows: minmax(240px, auto);
+  align-content: start;
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding-right: 8px;
+  max-height: clamp(480px, calc(100vh - 280px), 100%);
+  padding: 0 12px 8px 0;
 }
 
 .event-list::-webkit-scrollbar {
@@ -148,8 +155,8 @@
 .event-item {
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  padding: 20px 24px;
+  gap: 14px;
+  padding: 18px 20px;
   border-radius: 14px;
   background: rgba(30, 64, 175, 0.35);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.22);
@@ -165,7 +172,7 @@
 .event-info {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .event-header {
@@ -193,15 +200,15 @@
 .event-meta-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
 }
 
 .event-meta-chip {
   display: inline-flex;
   align-items: center;
-  padding: 6px 12px;
+  padding: 4px 10px;
   border-radius: 999px;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   letter-spacing: 0.04em;
   background: rgba(15, 23, 42, 0.55);
   color: #bae6fd;
@@ -209,38 +216,39 @@
 }
 
 .event-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  align-items: flex-start;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+  align-items: start;
   margin-top: auto;
   width: 100%;
 }
 
 .event-actions-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
   width: 100%;
 }
 
 .status-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
 }
 
 .status-label {
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 600;
   color: rgba(224, 242, 254, 0.9);
+  margin-right: 6px;
 }
 
 .status-button {
   background: rgba(34, 211, 238, 0.18);
   color: #e0f2fe;
-  padding: 8px 14px;
+  padding: 8px 12px;
 }
 
 .status-button:hover:not(:disabled) {
@@ -529,15 +537,13 @@
   }
 }
 
-@media (min-width: 1200px) {
-  .event-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+@media (max-width: 1199px) {
+  .event-actions {
+    grid-template-columns: minmax(0, 1fr);
   }
-}
 
-@media (min-width: 1600px) {
-  .event-list {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+  .event-actions-row {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 
@@ -566,6 +572,27 @@
 
   .event-item {
     padding: 16px;
+  }
+
+  .edit-events-card {
+    min-height: auto;
+  }
+
+  .event-list {
+    max-height: none;
+    padding-right: 8px;
+  }
+
+  .event-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .event-actions-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
   }
 
   .event-actions-row,


### PR DESCRIPTION
## Summary
- stretch the Manage Events section to use the full viewport height with clamped card and list sizing
- compact the event card grid and reduce spacing so more rows of events remain visible before scrolling
- keep action controls responsive by reflowing the button grid on medium and small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbca04343483239b863ba9de3efb7a