### PR TITLE
Fix desktop header layout to remain single row

### DIFF
--- a/bnkaraoke.web/src/components/Header.css
+++ b/bnkaraoke.web/src/components/Header.css
@@ -522,18 +522,28 @@
     flex-direction: row;
     align-items: center;
     gap: 15px;
+    flex-wrap: nowrap; /* Keep desktop layout on a single row */
+    width: 100%;
+  }
+  .header-main > * {
+    min-width: 0; /* Allow items to shrink to fit in one line */
   }
   .header-user {
     font-size: 1.2em;
   }
   .event-status {
     gap: 10px;
+    flex: 1 1 auto; /* Allow status text to flex between left and actions */
   }
   .event-name {
     font-size: 1em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis; /* Prevent long names from forcing a wrap */
   }
   .event-actions {
     flex-direction: row; /* Ensure horizontal layout on desktop */
+    align-items: center;
     gap: 10px;
   }
   .check-in-button,


### PR DESCRIPTION
## Summary
- prevent the desktop header from wrapping by keeping the flex layout on a single row
- allow status text to shrink with ellipsis so long event names do not force wrapping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc15a1a25483238e5927d81022ddee