### PR TITLE
Handle missing queue items table during event deletion

### DIFF
--- a/bnkaraoke.web/src/pages/EventManagement.tsx
+++ b/bnkaraoke.web/src/pages/EventManagement.tsx
@@ -648,7 +648,7 @@ const EventManagementPage: React.FC = () => {
                         <div className="event-info">
                           <div className="event-header">
                             <div className="event-title-wrapper">
-                              <span className="event-index-badge">#{index + 1}</span>
+                              <span className="event-index-badge">#{event.eventId}</span>
                               <p className="event-title">{event.description} ({event.eventCode})</p>
                             </div>
                             <span className={`status-pill status-${event.status.toLowerCase()}`}>{event.status}</span>


### PR DESCRIPTION
## Summary
- prevent DeleteEvent from aborting the transaction when the legacy QueueItems table is missing by wrapping the cleanup in a savepoint
- display each event's database ID in the Event Management badge instead of the list index

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc22c00ab08323b4d75e2a01a7f3d6