### PR TITLE
Refine event management card actions

### DIFF
--- a/bnkaraoke.web/src/pages/EventManagement.css
+++ b/bnkaraoke.web/src/pages/EventManagement.css
@@ -213,30 +213,58 @@
   box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.25);
 }
 .event-actions {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: stretch;
   margin-top: auto;
   width: 100%;
 }
-.event-actions-row {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+.event-action-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: rgba(15, 23, 42, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+}
+.event-action-section-title {
+  margin: 0;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: rgba(224, 242, 254, 0.85);
+}
+.event-action-buttons {
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   width: 100%;
 }
-.status-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  align-items: center;
+.event-action-buttons .action-button {
+  flex: 1 1 130px;
 }
-.status-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: rgba(224, 242, 254, 0.9);
-  margin-right: 6px;
+.event-action-buttons--controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+.event-action-buttons--controls .action-button,
+.status-buttons .action-button {
+  width: 100%;
+}
+.status-buttons {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+.visibility-toggle-button {
+  background: rgba(251, 191, 36, 0.25);
+  color: #fef3c7;
+}
+.visibility-toggle-button:hover:not(:disabled) {
+  background: rgba(251, 191, 36, 0.4);
 }
 .status-button {
   background: rgba(34, 211, 238, 0.18);


### PR DESCRIPTION
## Summary
- group event management card controls into dedicated sections and add a visibility toggle
- refresh the event management styles to support the new control layout

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dc258c081c83238d8a067d1cfbf7e5