### PR TITLE
Improve event management card layout

### DIFF
--- a/bnkaraoke.web/src/pages/EventManagement.css
+++ b/bnkaraoke.web/src/pages/EventManagement.css
@@ -1,6 +1,6 @@
 .event-management-container {
   flex: 1;
-  padding: 24px 24px 32px;
+  padding: 20px 20px 28px;
   background: linear-gradient(to bottom, #1e3a8a, #3b82f6);
   color: #f8fafc;
   display: flex;
@@ -18,9 +18,9 @@
 .event-management-header {
   display: flex;
   justify-content: space-between;
-  gap: 24px;
+  gap: 20px;
   align-items: flex-start;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 .event-management-heading {
   max-width: 640px;
@@ -79,7 +79,7 @@
 .event-management-card {
   background: rgba(15, 23, 42, 0.55);
   border-radius: 12px;
-  padding: 20px 24px;
+  padding: 18px 20px;
   box-shadow: 0 18px 40px rgba(15, 23, 42, 0.45);
   display: flex;
   flex-direction: column;
@@ -137,16 +137,16 @@
   border-radius: 999px;
 }
 .event-item {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 18px 20px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
+  gap: 16px;
+  padding: 16px 18px;
   border-radius: 14px;
   background: rgba(30, 64, 175, 0.35);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.22);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   height: auto;
-  min-height: 280px;
+  align-items: start;
 }
 .event-item:hover {
   transform: translateY(-2px);
@@ -156,6 +156,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  min-width: 0;
 }
 .event-header {
   display: flex;
@@ -213,12 +214,12 @@
   box-shadow: inset 0 0 0 1px rgba(56, 189, 248, 0.25);
 }
 .event-actions {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: 12px;
   align-items: stretch;
-  margin-top: auto;
   width: 100%;
+  min-width: 0;
 }
 .event-action-section {
   display: flex;
@@ -228,6 +229,7 @@
   border-radius: 10px;
   background: rgba(15, 23, 42, 0.45);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  height: 100%;
 }
 .event-action-section-title {
   margin: 0;
@@ -513,6 +515,11 @@
   }
 }
 @media (max-width: 1199px) {
+  .event-item {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
   .event-actions {
     grid-template-columns: minmax(0, 1fr);
   }


### PR DESCRIPTION
## Summary
- compact the event management page padding and card spacing to reclaim vertical space
- place event info and actions into responsive grids so more card content fits above the fold on wide screens
- ensure the layout gracefully falls back to a stacked view on smaller displays

## Testing
- npm run lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc358ee4648323bd5f6825ae5cb4d5