### PR TITLE
Improve event management page layout

### DIFF
--- a/bnkaraoke.web/src/pages/EventManagement.css
+++ b/bnkaraoke.web/src/pages/EventManagement.css
@@ -1,6 +1,6 @@
 .event-management-container {
-  flex: 1;
-  padding: 20px 20px 28px;
+  min-height: 100vh;
+  padding: 24px 24px 32px;
   background: linear-gradient(to bottom, #1e3a8a, #3b82f6);
   color: #f8fafc;
   display: flex;
@@ -12,7 +12,6 @@
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
   min-height: 0;
   overflow: auto;
 }
@@ -89,7 +88,7 @@
 .card-container {
   flex: 1 1 auto;
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   align-items: stretch;
   width: 100%;
   margin: 0 auto;
@@ -116,15 +115,15 @@
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 24px;
+  gap: 18px;
   grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-  grid-auto-rows: auto;
+  grid-auto-rows: minmax(240px, auto);
   align-content: start;
   flex: 1 1 auto;
   min-height: 0;
   overflow: visible;
   overflow-x: hidden;
-  padding: 4px 12px 8px 0;
+  padding: 0 12px 8px 0;
 }
 
 .event-item,
@@ -226,7 +225,8 @@
   width: 100%;
   min-width: 0;
 }
-.event-action-section {
+
+.event-section {
   display: grid;
   gap: 10px;
   padding: 12px 14px;
@@ -234,43 +234,32 @@
   background: rgba(15, 23, 42, 0.45);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
 }
-.event-action-section-title {
+
+.event-section-title {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  opacity: 0.95;
   margin: 0;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: rgba(224, 242, 254, 0.85);
 }
-.event-action-buttons {
+
+.event-section-buttons {
   display: grid;
+  gap: 8px;
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 10px;
   align-content: start;
-  width: 100%;
 }
-.event-action-buttons .action-button {
+
+.event-section-buttons .action-button {
   width: 100%;
-}
-.status-buttons {
-  display: contents;
 }
 
 .section-footer {
-  font-size: 0.75rem;
-  color: rgba(226, 232, 240, 0.7);
-  min-height: 1px;
+  margin-top: 2px;
+  opacity: 0.85;
+  font-size: 0.9rem;
 }
 
 @media (min-width: 1200px) {
-  .event-item {
-    flex-direction: row;
-    align-items: flex-start;
-  }
-
-  .event-info {
-    flex: 1.4;
-  }
-
   .event-actions {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -281,32 +270,33 @@
     grid-template-rows: auto 1fr auto;
   }
 
-  .event-action-section {
+  .event-section {
     grid-template-columns: subgrid;
     grid-template-rows: subgrid;
   }
 
-  .event-action-section .event-action-section-title,
-  .event-action-section .section-title {
+  .event-section .event-section-title {
     grid-row: 1;
     align-self: start;
   }
 
-  .event-action-section .event-action-buttons {
+  .event-section .event-section-buttons {
     grid-row: 2;
     align-self: start;
   }
 
-  .event-action-section .section-footer {
+  .event-section .section-footer {
     grid-row: 3;
     align-self: end;
   }
 }
-.visibility-toggle-button {
+.visibility-toggle-button,
+.hide-button {
   background: rgba(251, 191, 36, 0.25);
   color: #fef3c7;
 }
-.visibility-toggle-button:hover:not(:disabled) {
+.visibility-toggle-button:hover:not(:disabled),
+.hide-button:hover:not(:disabled) {
   background: rgba(251, 191, 36, 0.4);
 }
 .status-button {
@@ -561,18 +551,10 @@
     flex-direction: column;
     gap: 14px;
   }
-  .event-actions {
-    grid-template-columns: minmax(0, 1fr);
-  }
-  .event-actions-row {
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  }
 }
 @media (max-width: 768px) {
   .event-management-container {
     padding: 16px;
-    height: auto;
-    overflow: auto;
   }
   .event-management-title {
     font-size: 1.6rem;
@@ -595,23 +577,5 @@
   .event-list {
     max-height: none;
     padding-right: 8px;
-  }
-  .event-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-  .event-actions-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 10px;
-  }
-  .event-actions-row,
-  .status-actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  .status-label {
-    width: 100%;
   }
 }

--- a/bnkaraoke.web/src/pages/EventManagement.tsx
+++ b/bnkaraoke.web/src/pages/EventManagement.tsx
@@ -724,9 +724,9 @@ const EventManagementPage: React.FC = () => {
                           </div>
                         </div>
                         <div className="event-actions">
-                          <div className="event-action-section">
-                            <p className="event-action-section-title">Manage Details</p>
-                            <div className="event-action-buttons">
+                          <section className="event-section">
+                            <h4 className="event-section-title">Manage Details</h4>
+                            <div className="event-section-buttons">
                               <button
                                 className="action-button edit-button"
                                 onClick={() => setEditEvent({ ...event, eventId: event.eventId, eventCode: event.eventCode })}
@@ -744,13 +744,12 @@ const EventManagementPage: React.FC = () => {
                                 Delete
                               </button>
                             </div>
-                            <div className="section-footer">
-                              {isDeleting && <p className="event-action-note">Deleting event...</p>}
-                            </div>
-                          </div>
-                          <div className="event-action-section">
-                            <p className="event-action-section-title">Event Controls</p>
-                            <div className="event-action-buttons event-action-buttons--controls">
+                            <div className="section-footer" />
+                          </section>
+
+                          <section className="event-section">
+                            <h4 className="event-section-title">Event Controls</h4>
+                            <div className="event-section-buttons">
                               <button
                                 className="action-button start-button"
                                 onClick={() => startEvent(event.eventId, event.status)}
@@ -768,7 +767,7 @@ const EventManagementPage: React.FC = () => {
                                 End
                               </button>
                               <button
-                                className="action-button visibility-toggle-button"
+                                className="action-button hide-button visibility-toggle-button"
                                 onClick={() => toggleEventVisibility(event)}
                                 onTouchStart={() => toggleEventVisibility(event)}
                                 disabled={isBusy}
@@ -777,12 +776,13 @@ const EventManagementPage: React.FC = () => {
                               </button>
                             </div>
                             <div className="section-footer">
-                              {isVisibilityUpdating && <p className="event-action-note">Updating visibility...</p>}
+                              {isVisibilityUpdating && <span className="event-action-note">Updating visibility...</span>}
                             </div>
-                          </div>
-                          <div className="event-action-section">
-                            <p className="event-action-section-title">Status</p>
-                            <div className="event-action-buttons status-buttons">
+                          </section>
+
+                          <section className="event-section">
+                            <h4 className="event-section-title">Status</h4>
+                            <div className="event-section-buttons">
                               {statusOptions.map((option) => (
                                 <button
                                   key={option.value}
@@ -796,9 +796,10 @@ const EventManagementPage: React.FC = () => {
                               ))}
                             </div>
                             <div className="section-footer">
-                              {isStatusUpdating && <p className="event-action-note">Updating status...</p>}
+                              {isStatusUpdating && <span className="event-action-note">Updating status...</span>}
+                              {isDeleting && <span className="event-action-note">Deleting event...</span>}
                             </div>
-                          </div>
+                          </section>
                         </div>
                       </li>
                     );


### PR DESCRIPTION
## Summary
- ensure the event management pane fills the viewport with scrolling confined to the card grid
- reorganize card actions into three responsive sections with aligned titles/buttons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc5e57fa448323b2e53f78d5d0ceb1