### PR TITLE
Fix event management combobox and layout alignment

### DIFF
--- a/bnkaraoke.web/src/components/EventCombobox.tsx
+++ b/bnkaraoke.web/src/components/EventCombobox.tsx
@@ -87,7 +87,16 @@ const EventCombobox: React.FC<EventComboboxProps> = ({ events, selectedId, onSel
   const handleInputFocus = () => {
     if (events.length === 0) return;
     setOpen(true);
-    setQuery(selected ? formatLabel(selected) : "");
+    setQuery("");
+  };
+
+  const handleInputClick = () => {
+    if (events.length === 0) return;
+    if (open) {
+      return;
+    }
+    setOpen(true);
+    setQuery("");
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -149,6 +158,7 @@ const EventCombobox: React.FC<EventComboboxProps> = ({ events, selectedId, onSel
         placeholder={events.length === 0 ? "No events available" : "Search events…"}
         value={open ? query : selected ? formatLabel(selected) : ""}
         onFocus={handleInputFocus}
+        onClick={handleInputClick}
         onChange={(event) => {
           setOpen(true);
           setQuery(event.target.value);

--- a/bnkaraoke.web/src/pages/EventManagement.css
+++ b/bnkaraoke.web/src/pages/EventManagement.css
@@ -219,7 +219,7 @@
   gap: 12px;
   width: 100%;
   min-width: 0;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .event-action-section {
@@ -231,6 +231,7 @@
   background: rgba(15, 23, 42, 0.35);
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
   min-width: 0;
+  align-self: flex-start;
 }
 
 .event-section-title {


### PR DESCRIPTION
## Summary
- ensure the event management combobox opens with the full event list and can be reopened without typing
- adjust the event action layout so the Manage Details column aligns with the top of adjacent sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd329ede14832392c2d91c7cad745b