### PR TITLE
Add queue reorder modal UI scaffolding to DJ console

### DIFF
--- a/BNKaraoke.DJ/Models/ReorderQueuePreviewItem.cs
+++ b/BNKaraoke.DJ/Models/ReorderQueuePreviewItem.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+
+namespace BNKaraoke.DJ.Models
+{
+    public record ReorderQueuePreviewItem(
+        int QueueId,
+        int OriginalIndex,
+        int DisplayIndex,
+        string SongTitle,
+        string SongArtist,
+        string Requestor,
+        bool IsMature,
+        bool IsLocked,
+        bool IsDeferred,
+        int Movement,
+        IReadOnlyList<string> Reasons)
+    {
+        public string DisplayLabel => $"{DisplayIndex + 1}. {SongTitle}";
+
+        public string SecondaryLine
+        {
+            get
+            {
+                if (!string.IsNullOrWhiteSpace(SongArtist) && !string.IsNullOrWhiteSpace(Requestor))
+                {
+                    return $"{SongArtist} — {Requestor}";
+                }
+
+                if (!string.IsNullOrWhiteSpace(SongArtist))
+                {
+                    return SongArtist;
+                }
+
+                return Requestor;
+            }
+        }
+
+        public bool ShowMovement => Movement != 0;
+
+        public string MovementDescription => Movement switch
+        {
+            > 0 => $"↓ moved {Movement}",
+            < 0 => $"↑ moved {Math.Abs(Movement)}",
+            _ => ""
+        };
+
+        public bool ShowMaturePill => IsMature;
+
+        public string MaturePillText => IsDeferred ? "Deferred (Mature)" : "Mature";
+
+        public string Tooltip => Reasons.Count == 0
+            ? "No optimization reasoning available."
+            : string.Join(Environment.NewLine, Reasons);
+
+        public static ReorderQueuePreviewItem FromQueueEntry(int index, QueueEntry entry, bool isLocked)
+        {
+            if (entry == null)
+            {
+                throw new ArgumentNullException(nameof(entry));
+            }
+
+            var title = string.IsNullOrWhiteSpace(entry.SongTitle) ? "Unknown Song" : entry.SongTitle!;
+            var artist = string.IsNullOrWhiteSpace(entry.SongArtist) ? string.Empty : entry.SongArtist!;
+            var requestor = !string.IsNullOrWhiteSpace(entry.RequestorDisplayName)
+                ? entry.RequestorDisplayName!
+                : !string.IsNullOrWhiteSpace(entry.RequestorUserName)
+                    ? entry.RequestorUserName!
+                    : "Unknown Singer";
+
+            return new ReorderQueuePreviewItem(
+                entry.QueueId,
+                index,
+                index,
+                title,
+                artist,
+                requestor,
+                entry.IsMature,
+                isLocked,
+                false,
+                0,
+                Array.Empty<string>());
+        }
+    }
+}

--- a/BNKaraoke.DJ/ViewModels/ReorderQueueModalViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/ReorderQueueModalViewModel.cs
@@ -1,0 +1,338 @@
+using BNKaraoke.DJ.Models;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows;
+
+namespace BNKaraoke.DJ.ViewModels
+{
+    public enum ReorderMode
+    {
+        DeferMature,
+        AllowMature
+    }
+
+    public record ReorderHorizonOption(string Label, int? Value);
+
+    public record ReorderWarning(string Code, string Message);
+
+    public partial class ReorderQueueModalViewModel : ObservableObject
+    {
+        private const string AllMatureDeferredCode = "ALL_MATURE_DEFERRED";
+        private const int AreYouSureMoveThreshold = 8;
+        private const int LargeMoveDistanceThreshold = 5;
+        private bool _synchronizingMode;
+        private readonly IReadOnlyList<ReorderQueuePreviewItem> _snapshot;
+
+        public ObservableCollection<ReorderQueuePreviewItem> CurrentItems { get; }
+        public ObservableCollection<ReorderQueuePreviewItem> ProposedItems { get; } = new();
+        public ObservableCollection<ReorderWarning> Warnings { get; } = new();
+        public ObservableCollection<ReorderHorizonOption> HorizonOptions { get; }
+
+        [ObservableProperty]
+        private ReorderHorizonOption _selectedHorizon;
+
+        [ObservableProperty]
+        private bool _isDeferMature = true;
+
+        [ObservableProperty]
+        private bool _isAllowMature;
+
+        [ObservableProperty]
+        private int _maxMove = 4;
+
+        [ObservableProperty]
+        private bool _isMaxMoveEnabled;
+
+        [ObservableProperty]
+        private bool _isPreviewGenerated;
+
+        [ObservableProperty]
+        private bool _isApproveEnabled;
+
+        [ObservableProperty]
+        private bool _isApprovalBlocked;
+
+        [ObservableProperty]
+        private int _movedCount;
+
+        [ObservableProperty]
+        private double _fairnessBefore;
+
+        [ObservableProperty]
+        private double _fairnessAfter;
+
+        [ObservableProperty]
+        private bool _noAdjacentRepeat = true;
+
+        [ObservableProperty]
+        private string? _planId;
+
+        [ObservableProperty]
+        private string? _basedOnVersion;
+
+        [ObservableProperty]
+        private string _idempotencyKey = Guid.NewGuid().ToString("N");
+
+        [ObservableProperty]
+        private string _previewStatus = "Preview has not been generated.";
+
+        public bool IsApproved { get; private set; }
+
+        public event EventHandler<bool>? RequestClose;
+
+        public ReorderMode Mode => IsAllowMature ? ReorderMode.AllowMature : ReorderMode.DeferMature;
+
+        public int? Horizon => SelectedHorizon?.Value;
+
+        public int? MaxMoveConstraint => IsMaxMoveEnabled ? _maxMove : null;
+
+        public IEnumerable<string> WarningMessages => Warnings.Select(w => w.Message);
+
+        public bool HasWarnings => Warnings.Any();
+
+        public string AdjacentRepeatStatus => NoAdjacentRepeat ? "✓" : "✗";
+
+        public ReorderQueueModalViewModel(IEnumerable<ReorderQueuePreviewItem> snapshot, string? basedOnVersion = null)
+        {
+            _snapshot = snapshot?.ToList() ?? new List<ReorderQueuePreviewItem>();
+            CurrentItems = new ObservableCollection<ReorderQueuePreviewItem>(_snapshot);
+            _basedOnVersion = basedOnVersion;
+
+            HorizonOptions = new ObservableCollection<ReorderHorizonOption>(new[]
+            {
+                new ReorderHorizonOption("Entire queue", null),
+                new ReorderHorizonOption("Next 10", 10),
+                new ReorderHorizonOption("Next 20", 20)
+            });
+            _selectedHorizon = HorizonOptions.First();
+
+            Warnings.CollectionChanged += Warnings_CollectionChanged;
+            UpdateApproveState();
+        }
+
+        private void Warnings_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(WarningMessages));
+            OnPropertyChanged(nameof(HasWarnings));
+            UpdateApproveState();
+        }
+
+        partial void OnIsDeferMatureChanged(bool value)
+        {
+            if (_synchronizingMode)
+            {
+                return;
+            }
+
+            _synchronizingMode = true;
+            IsAllowMature = !value;
+            _synchronizingMode = false;
+            OnPropertyChanged(nameof(Mode));
+            InvalidatePreview();
+        }
+
+        partial void OnIsAllowMatureChanged(bool value)
+        {
+            if (_synchronizingMode)
+            {
+                return;
+            }
+
+            _synchronizingMode = true;
+            IsDeferMature = !value;
+            _synchronizingMode = false;
+            OnPropertyChanged(nameof(Mode));
+            InvalidatePreview();
+        }
+
+        partial void OnSelectedHorizonChanged(ReorderHorizonOption value)
+        {
+            OnPropertyChanged(nameof(Horizon));
+            InvalidatePreview();
+        }
+
+        partial void OnIsMaxMoveEnabledChanged(bool value)
+        {
+            OnPropertyChanged(nameof(MaxMoveConstraint));
+            InvalidatePreview();
+        }
+
+        partial void OnMaxMoveChanged(int value)
+        {
+            if (value < 1)
+            {
+                _maxMove = 1;
+            }
+
+            OnPropertyChanged(nameof(MaxMoveConstraint));
+            InvalidatePreview();
+        }
+
+        private void InvalidatePreview()
+        {
+            if (ProposedItems.Count > 0)
+            {
+                Log.Information("[REORDER MODAL] Preview invalidated due to configuration change.");
+            }
+
+            ProposedItems.Clear();
+            if (Warnings.Count > 0)
+            {
+                Warnings.Clear();
+            }
+
+            IsPreviewGenerated = false;
+            PreviewStatus = "Preview has not been generated.";
+            MovedCount = 0;
+            FairnessBefore = 0;
+            FairnessAfter = 0;
+            NoAdjacentRepeat = true;
+            UpdateApproveState();
+        }
+
+        [RelayCommand]
+        private void GeneratePreview()
+        {
+            try
+            {
+                ProposedItems.Clear();
+                if (Warnings.Count > 0)
+                {
+                    Warnings.Clear();
+                }
+
+                var defaultReasons = new List<string>
+                {
+                    "Preview reflects the current queue order. Optimization service is not yet connected."
+                };
+
+                if (Horizon.HasValue)
+                {
+                    defaultReasons.Add($"Preview limited to next {Horizon.Value} items.");
+                }
+
+                if (MaxMoveConstraint.HasValue)
+                {
+                    defaultReasons.Add($"Movement capped at {MaxMoveConstraint.Value} slots per item.");
+                }
+
+                foreach (var item in CurrentItems)
+                {
+                    var reasons = new List<string>(defaultReasons);
+                    var isDeferred = Mode == ReorderMode.DeferMature && item.IsMature && !item.IsLocked;
+                    if (isDeferred)
+                    {
+                        reasons.Add("Deferred because mature tracks cannot be scheduled in this mode.");
+                    }
+
+                    var proposed = item with
+                    {
+                        DisplayIndex = item.DisplayIndex,
+                        Movement = item.DisplayIndex - item.OriginalIndex,
+                        IsDeferred = isDeferred,
+                        Reasons = reasons
+                    };
+
+                    ProposedItems.Add(proposed);
+                }
+
+                PlanId = Guid.NewGuid().ToString("N");
+                IdempotencyKey = Guid.NewGuid().ToString("N");
+                IsPreviewGenerated = true;
+                PreviewStatus = "Preview generated. Review the proposed order before approving.";
+                FairnessBefore = 0.0;
+                FairnessAfter = 0.0;
+                NoAdjacentRepeat = true;
+                MovedCount = ProposedItems.Count(item => item.Movement != 0);
+
+                EvaluateWarnings();
+                UpdateApproveState();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "[REORDER MODAL] Failed to generate preview: {Message}", ex.Message);
+                PreviewStatus = $"Failed to generate preview: {ex.Message}";
+                ProposedItems.Clear();
+                UpdateApproveState();
+            }
+        }
+
+        [RelayCommand]
+        private void Approve()
+        {
+            if (!IsPreviewGenerated)
+            {
+                PreviewStatus = "Generate a preview before approving.";
+                return;
+            }
+
+            if (!IsApproveEnabled)
+            {
+                return;
+            }
+
+            var requiresConfirmation = MovedCount >= AreYouSureMoveThreshold
+                || ProposedItems.Any(item => Math.Abs(item.Movement) > LargeMoveDistanceThreshold)
+                || Mode == ReorderMode.AllowMature;
+
+            if (requiresConfirmation)
+            {
+                var result = MessageBox.Show(
+                    "Are you sure you want to apply this reorder plan?",
+                    "Confirm reorder",
+                    MessageBoxButton.YesNo,
+                    MessageBoxImage.Question);
+
+                if (result != MessageBoxResult.Yes)
+                {
+                    return;
+                }
+            }
+
+            IsApproved = true;
+            RequestClose?.Invoke(this, true);
+        }
+
+        [RelayCommand]
+        private void Cancel()
+        {
+            IsApproved = false;
+            RequestClose?.Invoke(this, false);
+        }
+
+        private void EvaluateWarnings()
+        {
+            if (Mode == ReorderMode.DeferMature)
+            {
+                var reorderable = ProposedItems.Where(item => !item.IsLocked).ToList();
+                if (reorderable.Count > 0 && reorderable.All(item => item.IsDeferred || item.IsMature))
+                {
+                    AddWarning(new ReorderWarning(
+                        AllMatureDeferredCode,
+                        "All mature tracks are deferred. No playable songs remain within the selected horizon."));
+                }
+            }
+        }
+
+        private void AddWarning(ReorderWarning warning)
+        {
+            if (Warnings.All(existing => existing.Code != warning.Code))
+            {
+                Warnings.Add(warning);
+            }
+        }
+
+        private void UpdateApproveState()
+        {
+            IsApprovalBlocked = Warnings.Any(warning => warning.Code == AllMatureDeferredCode);
+            IsApproveEnabled = IsPreviewGenerated && !IsApprovalBlocked;
+            OnPropertyChanged(nameof(AdjacentRepeatStatus));
+        }
+    }
+}

--- a/BNKaraoke.DJ/Views/DJScreen.xaml
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml
@@ -296,6 +296,7 @@
                         <ListView x:Name="QueueListView" ItemsSource="{Binding QueueEntries}" Margin="5"
                                   SelectedItem="{Binding SelectedQueueEntry}" AllowDrop="True"
                                   PreviewMouseLeftButtonDown="ListViewItem_PreviewMouseLeftButtonDown"
+                                  ContextMenuOpening="QueueListView_ContextMenuOpening"
                                   VerticalAlignment="Stretch">
                             <i:Interaction.Behaviors>
                                 <behaviors:DragDropBehavior DropCommand="{Binding DropCommand}"/>
@@ -347,6 +348,15 @@
                                     <Setter Property="Padding" Value="10"/>
                                     <Setter Property="BorderBrush" Value="#ccc"/>
                                     <Setter Property="BorderThickness" Value="0,0,0,1"/>
+                                    <Setter Property="ContextMenu">
+                                        <Setter.Value>
+                                            <ContextMenu>
+                                                <MenuItem Header="Show Details"
+                                                          Command="{Binding DataContext.ShowSongDetailsCommand, RelativeSource={RelativeSource AncestorType=ListView}}"
+                                                          CommandParameter="{Binding}"/>
+                                            </ContextMenu>
+                                        </Setter.Value>
+                                    </Setter>
                                     <EventSetter Event="PreviewMouseDoubleClick" Handler="QueueListView_PreviewMouseDoubleClick"/>
                                     <Style.Triggers>
                                         <DataTrigger Binding="{Binding IsUpNext, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Value="True">
@@ -413,7 +423,7 @@
                             </ListView.ItemContainerStyle>
                             <ListView.ContextMenu>
                                 <ContextMenu>
-                                    <MenuItem Header="Show Details" Command="{Binding ShowSongDetailsCommand}"/>
+                                    <MenuItem Header="Reorder Queue..." Command="{Binding OpenReorderModalCommand}"/>
                                 </ContextMenu>
                             </ListView.ContextMenu>
                         </ListView>

--- a/BNKaraoke.DJ/Views/DJScreen.xaml.cs
+++ b/BNKaraoke.DJ/Views/DJScreen.xaml.cs
@@ -117,6 +117,33 @@ namespace BNKaraoke.DJ.Views
             }
         }
 
+        private void QueueListView_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+        {
+            try
+            {
+                if (sender is not ListView listView)
+                {
+                    return;
+                }
+
+                if (e.OriginalSource is DependencyObject source)
+                {
+                    if (ItemsControl.ContainerFromElement(listView, source) is ListViewItem item)
+                    {
+                        listView.SelectedItem = item.DataContext;
+                        if (DataContext is DJScreenViewModel viewModel && item.DataContext is QueueEntry queueEntry)
+                        {
+                            viewModel.SelectedQueueEntry = queueEntry;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error("[DJSCREEN] Failed during queue context menu opening: {Message}", ex.Message);
+            }
+        }
+
         private void SingersContextMenu_Opening(object sender, ContextMenuEventArgs e)
         {
             try

--- a/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
+++ b/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
@@ -1,0 +1,184 @@
+<Window x:Class="BNKaraoke.DJ.Views.ReorderQueueModal"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:models="clr-namespace:BNKaraoke.DJ.Models"
+        mc:Ignorable="d"
+        Title="Reorder Queue"
+        Width="900"
+        Height="640"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        Background="#111827"
+        DataContextChanged="Window_DataContextChanged">
+    <Window.Resources>
+        <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+    </Window.Resources>
+    <Grid Margin="20">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,12">
+            <TextBlock Text="Reorder Queue" FontSize="24" FontWeight="Bold" Foreground="White" />
+            <TextBlock Text="Use the optimizer preview to evaluate a new play order before applying it to the event queue."
+                       FontSize="14" Foreground="#D1D5DB" Margin="0,8,0,0" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Border Grid.Row="1" Padding="12" Background="#1F2937" CornerRadius="6">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="Mature policy" FontWeight="SemiBold" Foreground="#9CA3AF" />
+                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                        <RadioButton Content="Defer Mature" IsChecked="{Binding IsDeferMature}"
+                                     Foreground="White" GroupName="MaturePolicy" Margin="0,0,12,0" />
+                        <RadioButton Content="Allow Mature" IsChecked="{Binding IsAllowMature}"
+                                     Foreground="White" GroupName="MaturePolicy" />
+                    </StackPanel>
+                </StackPanel>
+                <StackPanel Grid.Column="1" Margin="12,0,0,0">
+                    <TextBlock Text="Horizon" FontWeight="SemiBold" Foreground="#9CA3AF" />
+                    <ComboBox ItemsSource="{Binding HorizonOptions}" SelectedItem="{Binding SelectedHorizon}" DisplayMemberPath="Label"
+                              Margin="0,6,0,0" Width="160" />
+                </StackPanel>
+                <StackPanel Grid.Column="2" Margin="12,0,0,0">
+                    <TextBlock Text="Max move distance" FontWeight="SemiBold" Foreground="#9CA3AF" />
+                    <StackPanel Orientation="Horizontal" Margin="0,6,0,0" VerticalAlignment="Center">
+                        <CheckBox Content="Limit" IsChecked="{Binding IsMaxMoveEnabled}" Foreground="White" />
+                        <Slider Width="140" Margin="12,0,0,0" Minimum="1" Maximum="10" TickFrequency="1" IsSnapToTickEnabled="True"
+                                Value="{Binding MaxMove}" IsEnabled="{Binding IsMaxMoveEnabled}" />
+                        <TextBlock Text="{Binding MaxMove}" Margin="12,0,0,0" VerticalAlignment="Center" Foreground="White" />
+                    </StackPanel>
+                </StackPanel>
+                <StackPanel Grid.Column="3" HorizontalAlignment="Right" VerticalAlignment="Center">
+                    <Button Content="Generate Preview" Command="{Binding GeneratePreviewCommand}" Width="160"
+                            Height="36" Margin="12,0,0,0" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <StackPanel Grid.Row="2" Margin="0,16,0,0">
+            <Border Background="#FBBF24" Padding="12" CornerRadius="6" Margin="0,0,0,12"
+                    Visibility="{Binding HasWarnings, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <StackPanel>
+                    <TextBlock Text="Warnings" FontWeight="Bold" Foreground="#1F2937" />
+                    <ItemsControl ItemsSource="{Binding WarningMessages}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
+                                    <TextBlock Text="•" Foreground="#1F2937" Margin="0,0,6,0" />
+                                    <TextBlock Text="{Binding}" Foreground="#1F2937" TextWrapping="Wrap" />
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+            </Border>
+
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <StackPanel Grid.Column="0">
+                    <TextBlock Text="Current order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
+                    <ListBox ItemsSource="{Binding CurrentItems}" Background="#111827" BorderBrush="#374151">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
+                                <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
+                                        ToolTipService.ToolTip="{Binding Tooltip}">
+                                    <StackPanel>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
+                                            <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                    Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
+                                            </Border>
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+
+                <Border Grid.Column="1" Width="24" />
+
+                <StackPanel Grid.Column="2">
+                    <TextBlock Text="Proposed order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
+                    <ListBox ItemsSource="{Binding ProposedItems}" Background="#111827" BorderBrush="#374151">
+                        <ListBox.ItemContainerStyle>
+                            <Style TargetType="ListBoxItem">
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
+                                <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
+                                        ToolTipService.ToolTip="{Binding Tooltip}">
+                                    <StackPanel>
+                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
+                                            <Border Background="#F97316" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                    Visibility="{Binding ShowMovement, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <TextBlock Text="{Binding MovementDescription}" Foreground="White" FontSize="12" />
+                                            </Border>
+                                            <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                    Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
+                                            </Border>
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                </StackPanel>
+            </Grid>
+
+            <TextBlock Text="{Binding PreviewStatus}" Foreground="#9CA3AF" Margin="0,12,0,0" TextWrapping="Wrap" />
+        </StackPanel>
+
+        <Border Grid.Row="3" Background="#1F2937" CornerRadius="6" Padding="12" Margin="0,16,0,0">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                <TextBlock Text="Moved:" Foreground="#9CA3AF" FontWeight="SemiBold" />
+                <TextBlock Text=" {Binding MovedCount}" Foreground="White" Margin="4,0,12,0" />
+                <TextBlock Text="Fairness:" Foreground="#9CA3AF" FontWeight="SemiBold" />
+                <TextBlock Text=" {Binding FairnessBefore, StringFormat={}{0:0.00}} → {Binding FairnessAfter, StringFormat={}{0:0.00}}"
+                           Foreground="White" Margin="4,0,12,0" />
+                <TextBlock Text="No adjacent repeats:" Foreground="#9CA3AF" FontWeight="SemiBold" />
+                <TextBlock Text=" {Binding AdjacentRepeatStatus}" Foreground="White" Margin="4,0,0,0" />
+            </StackPanel>
+        </Border>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+            <Border Background="#F59E0B" Padding="12" CornerRadius="6" Margin="0,0,12,0"
+                    Visibility="{Binding IsApprovalBlocked, Converter={StaticResource BooleanToVisibilityConverter}}">
+                <TextBlock Text="All mature tracks are deferred. Approve is disabled." Foreground="#1F2937" FontWeight="SemiBold" />
+            </Border>
+            <Button Content="Approve" Command="{Binding ApproveCommand}" Width="120" Height="36" Margin="0,0,12,0"
+                    IsEnabled="{Binding IsApproveEnabled}" />
+            <Button Content="Cancel" Command="{Binding CancelCommand}" Width="120" Height="36" IsCancel="True" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/BNKaraoke.DJ/Views/ReorderQueueModal.xaml.cs
+++ b/BNKaraoke.DJ/Views/ReorderQueueModal.xaml.cs
@@ -1,0 +1,32 @@
+using BNKaraoke.DJ.ViewModels;
+using System.Windows;
+
+namespace BNKaraoke.DJ.Views
+{
+    public partial class ReorderQueueModal : Window
+    {
+        public ReorderQueueModal()
+        {
+            InitializeComponent();
+        }
+
+        private void Window_DataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.OldValue is ReorderQueueModalViewModel oldViewModel)
+            {
+                oldViewModel.RequestClose -= OnRequestClose;
+            }
+
+            if (e.NewValue is ReorderQueueModalViewModel newViewModel)
+            {
+                newViewModel.RequestClose += OnRequestClose;
+            }
+        }
+
+        private void OnRequestClose(object? sender, bool approved)
+        {
+            DialogResult = approved;
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a list background context menu entry that launches a new queue reorder experience from the DJ screen
- introduce the ReorderQueueModal window, view-model, and supporting preview item model to display current/proposed queue order, metrics, and warnings
- wire the DJ screen view-model to capture queue snapshots and open the modal while keeping song-row context menus focused on song details

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7730b58c8323b53c89cc4ef4d554