### PR TITLE
Integrate server-backed queue reorder preview and apply

### DIFF
--- a/BNKaraoke.DJ/Models/DjSettings.cs
+++ b/BNKaraoke.DJ/Models/DjSettings.cs
@@ -25,5 +25,7 @@ namespace BNKaraoke.DJ.Models
         public string? AudioOutputDeviceId { get; set; }
         public bool AllowDirectSoundFallback { get; set; } = true;
         public bool EnableAudioEngineRestartButton { get; set; } = true;
+        public string DefaultReorderMaturePolicy { get; set; } = "Defer";
+        public int QueueReorderConfirmationThreshold { get; set; } = 6;
     }
 }

--- a/BNKaraoke.DJ/Models/ReorderContracts.cs
+++ b/BNKaraoke.DJ/Models/ReorderContracts.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+namespace BNKaraoke.DJ.Models
+{
+    public enum ReorderMode
+    {
+        DeferMature,
+        AllowMature
+    }
+
+    public static class ReorderModeExtensions
+    {
+        public static string ToMaturePolicy(this ReorderMode mode)
+        {
+            return mode == ReorderMode.AllowMature ? "Allow" : "Defer";
+        }
+    }
+
+    public record ReorderWarning(string Code, string Message, bool BlocksApproval = false);
+
+    public class ReorderPreviewRequest
+    {
+        public int EventId { get; set; }
+        public string? BasedOnVersion { get; set; }
+        public string? MaturePolicy { get; set; }
+        public int? Horizon { get; set; }
+        public int? MovementCap { get; set; }
+    }
+
+    public record ReorderPreviewSummary(
+        int MoveCount,
+        double FairnessBefore,
+        double FairnessAfter,
+        bool NoAdjacentRepeat,
+        bool RequiresConfirmation);
+
+    public record ReorderPreviewDiff(string Code, string Message);
+
+    public record ReorderPreviewResponse(
+        string PlanId,
+        string BasedOnVersion,
+        string ProposedVersion,
+        DateTime ExpiresAt,
+        ReorderPreviewSummary Summary,
+        IReadOnlyList<ReorderQueuePreviewItem> Items,
+        IReadOnlyList<ReorderWarning> Warnings,
+        IReadOnlyList<ReorderPreviewDiff>? Diffs = null);
+
+    public class ReorderApplyRequest
+    {
+        public int EventId { get; set; }
+        public string PlanId { get; set; } = string.Empty;
+        public string BasedOnVersion { get; set; } = string.Empty;
+        public string? IdempotencyKey { get; set; }
+    }
+
+    public record ReorderApplyResponse(
+        string AppliedVersion,
+        int MoveCount,
+        DateTime AppliedAt);
+
+    public record ReorderErrorResponse(
+        string Message,
+        IReadOnlyList<ReorderWarning> Warnings);
+}

--- a/BNKaraoke.DJ/Models/ReorderQueuePreviewItem.cs
+++ b/BNKaraoke.DJ/Models/ReorderQueuePreviewItem.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace BNKaraoke.DJ.Models
 {
+    [JsonConstructor]
     public record ReorderQueuePreviewItem(
         int QueueId,
         int OriginalIndex,

--- a/BNKaraoke.DJ/Services/ApiRequestException.cs
+++ b/BNKaraoke.DJ/Services/ApiRequestException.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using BNKaraoke.DJ.Models;
+
+namespace BNKaraoke.DJ.Services
+{
+    public class ApiRequestException : Exception
+    {
+        public HttpStatusCode StatusCode { get; }
+        public IReadOnlyList<ReorderWarning> Warnings { get; }
+        public string? CurrentVersion { get; }
+
+        public ApiRequestException(
+            string message,
+            HttpStatusCode statusCode,
+            IReadOnlyList<ReorderWarning>? warnings = null,
+            string? currentVersion = null,
+            Exception? innerException = null)
+            : base(message, innerException)
+        {
+            StatusCode = statusCode;
+            Warnings = warnings ?? Array.Empty<ReorderWarning>();
+            CurrentVersion = currentVersion;
+        }
+    }
+}

--- a/BNKaraoke.DJ/Services/IApiService.cs
+++ b/BNKaraoke.DJ/Services/IApiService.cs
@@ -19,6 +19,8 @@ namespace BNKaraoke.DJ.Services
         Task<List<QueueEntry>> GetSungQueueAsync(string eventId);
         Task<int> GetSungCountAsync(string eventId);
         Task ReorderQueueAsync(string eventId, List<QueuePosition> newOrder);
+        Task<ReorderPreviewResponse> PreviewQueueReorderAsync(ReorderPreviewRequest request, CancellationToken cancellationToken = default);
+        Task<ReorderApplyResponse> ApplyQueueReorderAsync(ReorderApplyRequest request, CancellationToken cancellationToken = default);
         Task ResetNowPlayingAsync(string eventId);
         Task PlayAsync(string eventId, string queueId);
         Task PauseAsync(string eventId, string queueId);

--- a/BNKaraoke.DJ/Services/SettingsService.cs
+++ b/BNKaraoke.DJ/Services/SettingsService.cs
@@ -55,6 +55,14 @@ namespace BNKaraoke.DJ.Services
                         {
                             settings.AudioOutputModule = "mmdevice";
                         }
+                        if (string.IsNullOrWhiteSpace(settings.DefaultReorderMaturePolicy))
+                        {
+                            settings.DefaultReorderMaturePolicy = "Defer";
+                        }
+                        if (settings.QueueReorderConfirmationThreshold <= 0)
+                        {
+                            settings.QueueReorderConfirmationThreshold = 6;
+                        }
                         return settings;
                     }
                 }

--- a/BNKaraoke.DJ/ViewModels/ReorderQueueModalViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/ReorderQueueModalViewModel.cs
@@ -1,4 +1,5 @@
 using BNKaraoke.DJ.Models;
+using BNKaraoke.DJ.Services;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Serilog;
@@ -7,38 +8,39 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 
 namespace BNKaraoke.DJ.ViewModels
 {
-    public enum ReorderMode
-    {
-        DeferMature,
-        AllowMature
-    }
-
     public record ReorderHorizonOption(string Label, int? Value);
-
-    public record ReorderWarning(string Code, string Message);
 
     public partial class ReorderQueueModalViewModel : ObservableObject
     {
         private const string AllMatureDeferredCode = "ALL_MATURE_DEFERRED";
-        private const int AreYouSureMoveThreshold = 8;
-        private const int LargeMoveDistanceThreshold = 5;
-        private bool _synchronizingMode;
+
+        private readonly IApiService _apiService;
+        private readonly SettingsService _settingsService;
         private readonly IReadOnlyList<ReorderQueuePreviewItem> _snapshot;
+        private readonly int _eventId;
+        private readonly int _confirmationThreshold;
+        private bool _synchronizingMode;
+        private bool _requiresConfirmation;
+        private CancellationTokenSource? _previewCts;
 
         public ObservableCollection<ReorderQueuePreviewItem> CurrentItems { get; }
         public ObservableCollection<ReorderQueuePreviewItem> ProposedItems { get; } = new();
         public ObservableCollection<ReorderWarning> Warnings { get; } = new();
+        public ObservableCollection<ReorderPreviewDiff> Diffs { get; } = new();
         public ObservableCollection<ReorderHorizonOption> HorizonOptions { get; }
 
         [ObservableProperty]
         private ReorderHorizonOption _selectedHorizon;
 
         [ObservableProperty]
-        private bool _isDeferMature = true;
+        private bool _isDeferMature;
 
         [ObservableProperty]
         private bool _isAllowMature;
@@ -77,10 +79,19 @@ namespace BNKaraoke.DJ.ViewModels
         private string? _basedOnVersion;
 
         [ObservableProperty]
+        private string? _proposedVersion;
+
+        [ObservableProperty]
+        private DateTime? _planExpiresAt;
+
+        [ObservableProperty]
         private string _idempotencyKey = Guid.NewGuid().ToString("N");
 
         [ObservableProperty]
         private string _previewStatus = "Preview has not been generated.";
+
+        [ObservableProperty]
+        private bool _isBusy;
 
         public bool IsApproved { get; private set; }
 
@@ -98,11 +109,21 @@ namespace BNKaraoke.DJ.ViewModels
 
         public string AdjacentRepeatStatus => NoAdjacentRepeat ? "✓" : "✗";
 
-        public ReorderQueueModalViewModel(IEnumerable<ReorderQueuePreviewItem> snapshot, string? basedOnVersion = null)
+        public ReorderQueueModalViewModel(
+            IApiService apiService,
+            SettingsService settingsService,
+            int eventId,
+            IEnumerable<ReorderQueuePreviewItem> snapshot,
+            string? basedOnVersion = null)
         {
+            _apiService = apiService ?? throw new ArgumentNullException(nameof(apiService));
+            _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
+            _eventId = eventId;
             _snapshot = snapshot?.ToList() ?? new List<ReorderQueuePreviewItem>();
-            CurrentItems = new ObservableCollection<ReorderQueuePreviewItem>(_snapshot);
+            _confirmationThreshold = Math.Max(1, _settingsService.Settings.QueueReorderConfirmationThreshold);
             _basedOnVersion = basedOnVersion;
+
+            CurrentItems = new ObservableCollection<ReorderQueuePreviewItem>(_snapshot);
 
             HorizonOptions = new ObservableCollection<ReorderHorizonOption>(new[]
             {
@@ -112,8 +133,24 @@ namespace BNKaraoke.DJ.ViewModels
             });
             _selectedHorizon = HorizonOptions.First();
 
+            ConfigureDefaultMatureMode(_settingsService.Settings.DefaultReorderMaturePolicy);
+
             Warnings.CollectionChanged += Warnings_CollectionChanged;
             UpdateApproveState();
+        }
+
+        private void ConfigureDefaultMatureMode(string? policy)
+        {
+            var defaultMode = ReorderMode.DeferMature;
+            if (!string.IsNullOrWhiteSpace(policy) && Enum.TryParse(policy, true, out ReorderMode parsed))
+            {
+                defaultMode = parsed;
+            }
+
+            _synchronizingMode = true;
+            IsDeferMature = defaultMode != ReorderMode.AllowMature;
+            IsAllowMature = defaultMode == ReorderMode.AllowMature;
+            _synchronizingMode = false;
         }
 
         private void Warnings_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -177,19 +214,26 @@ namespace BNKaraoke.DJ.ViewModels
 
         private void InvalidatePreview()
         {
+            _previewCts?.Cancel();
+
             if (ProposedItems.Count > 0)
             {
                 Log.Information("[REORDER MODAL] Preview invalidated due to configuration change.");
             }
 
             ProposedItems.Clear();
+            Diffs.Clear();
             if (Warnings.Count > 0)
             {
                 Warnings.Clear();
             }
 
+            _requiresConfirmation = false;
             IsPreviewGenerated = false;
             PreviewStatus = "Preview has not been generated.";
+            PlanId = null;
+            ProposedVersion = null;
+            PlanExpiresAt = null;
             MovedCount = 0;
             FairnessBefore = 0;
             FairnessAfter = 0;
@@ -198,357 +242,149 @@ namespace BNKaraoke.DJ.ViewModels
         }
 
         [RelayCommand]
-        private void GeneratePreview()
+        private async Task GeneratePreviewAsync()
         {
+            if (_isBusy)
+            {
+                Log.Information("[REORDER MODAL] Cancelling previous preview request.");
+                _previewCts?.Cancel();
+            }
+
+            var cts = new CancellationTokenSource();
+            _previewCts = cts;
+            var token = cts.Token;
+
             try
             {
+                IsBusy = true;
+                PreviewStatus = "Generating preview…";
                 ProposedItems.Clear();
+                Diffs.Clear();
                 if (Warnings.Count > 0)
                 {
                     Warnings.Clear();
                 }
+                UpdateApproveState();
 
-                var orderedSnapshot = CurrentItems
-                    .OrderBy(item => item.DisplayIndex)
-                    .Select((item, index) => item with { DisplayIndex = index })
-                    .ToList();
-
-                if (orderedSnapshot.Count == 0)
+                var request = new ReorderPreviewRequest
                 {
-                    PreviewStatus = "Queue is empty. Nothing to preview.";
-                    UpdateApproveState();
-                    return;
-                }
+                    EventId = _eventId,
+                    BasedOnVersion = BasedOnVersion,
+                    MaturePolicy = Mode.ToMaturePolicy(),
+                    Horizon = Horizon,
+                    MovementCap = MaxMoveConstraint
+                };
 
-                var horizonCount = Horizon.HasValue
-                    ? Math.Min(Horizon.Value, orderedSnapshot.Count)
-                    : orderedSnapshot.Count;
+                Log.Information(
+                    "[REORDER MODAL] Requesting preview for EventId={EventId}, Mode={Mode}, Horizon={Horizon}, MovementCap={MovementCap}",
+                    request.EventId,
+                    request.MaturePolicy,
+                    request.Horizon,
+                    request.MovementCap);
 
-                var defaultReasons = BuildDefaultReasons(horizonCount);
-
-                var reorderableWindow = orderedSnapshot.Take(horizonCount).ToList();
-                var reorderableItems = reorderableWindow.Where(item => !item.IsLocked).ToList();
-
-                if (reorderableItems.Count == 0)
-                {
-                    foreach (var item in orderedSnapshot)
-                    {
-                        var reasons = BuildReasonsForUnchangedItem(item, defaultReasons, horizonCount);
-                        ProposedItems.Add(CreateProposedItem(item, item.DisplayIndex, reasons, isDeferred: false));
-                    }
-
-                    FinalizePreviewMetadata(orderedSnapshot, ProposedItems.ToList(), horizonCount);
-                    return;
-                }
-
-                var remainingCandidates = PrioritizeItems(reorderableItems);
-
-                var proposedOrder = new List<ReorderQueuePreviewItem>(orderedSnapshot.Count);
-
-                for (var displayIndex = 0; displayIndex < orderedSnapshot.Count; displayIndex++)
-                {
-                    var snapshotItem = orderedSnapshot[displayIndex];
-
-                    if (displayIndex >= horizonCount)
-                    {
-                        var reasons = BuildReasonsOutsideHorizon(snapshotItem, defaultReasons);
-                        proposedOrder.Add(CreateProposedItem(snapshotItem, displayIndex, reasons, isDeferred: false));
-                        continue;
-                    }
-
-                    if (snapshotItem.IsLocked)
-                    {
-                        var reasons = BuildReasonsForLockedItem(snapshotItem, defaultReasons);
-                        proposedOrder.Add(CreateProposedItem(snapshotItem, displayIndex, reasons, isDeferred: false));
-                        continue;
-                    }
-
-                    if (remainingCandidates.Count == 0)
-                    {
-                        var reasons = BuildReasonsForUnchangedItem(snapshotItem, defaultReasons, horizonCount);
-                        proposedOrder.Add(CreateProposedItem(snapshotItem, displayIndex, reasons, isDeferred: false));
-                        continue;
-                    }
-
-                    var previousItem = proposedOrder.LastOrDefault();
-                    var candidateIndex = FindNextCandidateIndex(remainingCandidates, previousItem, displayIndex, MaxMoveConstraint);
-                    var candidate = remainingCandidates[candidateIndex];
-                    remainingCandidates.RemoveAt(candidateIndex);
-
-                    var reasonsForItem = BuildReasonsForAssignment(candidate, previousItem, defaultReasons, displayIndex);
-                    var isDeferred = Mode == ReorderMode.DeferMature && candidate.IsMature && !candidate.IsLocked;
-                    var proposed = CreateProposedItem(candidate, displayIndex, reasonsForItem, isDeferred);
-                    proposedOrder.Add(proposed);
-                }
-
-                ProposedItems.Clear();
-                foreach (var item in proposedOrder)
-                {
-                    ProposedItems.Add(item);
-                }
-
-                FinalizePreviewMetadata(orderedSnapshot, proposedOrder, horizonCount);
+                var response = await _apiService.PreviewQueueReorderAsync(request, token);
+                ApplyPreviewResponse(response);
+            }
+            catch (ApiRequestException apiEx) when (!token.IsCancellationRequested)
+            {
+                Log.Warning(apiEx, "[REORDER MODAL] Preview request returned API error: {Message}", apiEx.Message);
+                PreviewStatus = apiEx.Message;
+                PopulateWarnings(apiEx.Warnings);
+            }
+            catch (HttpRequestException ex) when (!token.IsCancellationRequested)
+            {
+                Log.Error(ex, "[REORDER MODAL] HTTP failure during preview: {Message}", ex.Message);
+                PreviewStatus = $"Failed to generate preview: {ex.Message}";
+            }
+            catch (TaskCanceledException) when (token.IsCancellationRequested)
+            {
+                Log.Information("[REORDER MODAL] Preview request cancelled.");
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "[REORDER MODAL] Failed to generate preview: {Message}", ex.Message);
+                Log.Error(ex, "[REORDER MODAL] Unexpected error during preview: {Message}", ex.Message);
                 PreviewStatus = $"Failed to generate preview: {ex.Message}";
-                ProposedItems.Clear();
+            }
+            finally
+            {
+                if (_previewCts == cts)
+                {
+                    _previewCts = null;
+                }
+
+                IsBusy = false;
                 UpdateApproveState();
             }
         }
 
-        private List<string> BuildDefaultReasons(int horizonCount)
+        private void ApplyPreviewResponse(ReorderPreviewResponse response)
         {
-            var reasons = new List<string>
+            if (response == null)
             {
-                "Preview generated using local optimization heuristics."
-            };
-
-            if (Horizon.HasValue)
-            {
-                reasons.Add($"Preview limited to next {Math.Max(1, horizonCount)} items.");
+                PreviewStatus = "Preview response was empty.";
+                return;
             }
 
-            if (MaxMoveConstraint.HasValue)
-            {
-                reasons.Add($"Movement capped at {MaxMoveConstraint.Value} slots per item.");
-            }
-
-            return reasons;
-        }
-
-        private static List<string> BuildReasonsForUnchangedItem(
-            ReorderQueuePreviewItem item,
-            IReadOnlyCollection<string> defaultReasons,
-            int horizonCount)
-        {
-            var reasons = new List<string>(defaultReasons)
-            {
-                "No viable alternative slot was identified within the configured horizon."
-            };
-
-            if (item.IsLocked)
-            {
-                reasons.Add("Entry is locked and cannot be moved.");
-            }
-            else if (item.DisplayIndex >= horizonCount)
-            {
-                reasons.Add("Entry falls outside the optimization horizon.");
-            }
-
-            return reasons;
-        }
-
-        private static List<string> BuildReasonsOutsideHorizon(
-            ReorderQueuePreviewItem item,
-            IReadOnlyCollection<string> defaultReasons)
-        {
-            var reasons = new List<string>(defaultReasons)
-            {
-                "Position retained because the item is outside the optimization horizon."
-            };
-
-            if (item.IsMature)
-            {
-                reasons.Add("Mature status respected outside the optimization window.");
-            }
-
-            return reasons;
-        }
-
-        private static List<string> BuildReasonsForLockedItem(
-            ReorderQueuePreviewItem item,
-            IReadOnlyCollection<string> defaultReasons)
-        {
-            var reasons = new List<string>(defaultReasons)
-            {
-                "Position locked (currently playing or up next)."
-            };
-
-            return reasons;
-        }
-
-        private List<string> BuildReasonsForAssignment(
-            ReorderQueuePreviewItem candidate,
-            ReorderQueuePreviewItem? previousItem,
-            IReadOnlyCollection<string> defaultReasons,
-            int targetIndex)
-        {
-            var reasons = new List<string>(defaultReasons);
-
-            if (previousItem == null)
-            {
-                reasons.Add("Starting point selected based on queue order and singer availability.");
-            }
-            else if (!string.IsNullOrWhiteSpace(previousItem.Requestor) &&
-                     !string.IsNullOrWhiteSpace(candidate.Requestor) &&
-                     string.Equals(previousItem.Requestor, candidate.Requestor, StringComparison.OrdinalIgnoreCase))
-            {
-                reasons.Add("Kept adjacent to the same singer because no alternative satisfied the constraints.");
-            }
-            else
-            {
-                reasons.Add("Position adjusted to avoid back-to-back songs from the same singer.");
-            }
-
-            if (targetIndex == candidate.OriginalIndex)
-            {
-                reasons.Add("Remains in original relative position.");
-            }
-            else
-            {
-                reasons.Add($"Moved from position {candidate.OriginalIndex + 1} to {targetIndex + 1} to improve rotation.");
-            }
-
-            if (Mode == ReorderMode.DeferMature && candidate.IsMature && !candidate.IsLocked)
-            {
-                reasons.Add("Scheduled later due to Defer Mature mode.");
-            }
-
-            return reasons;
-        }
-
-        private static int FindNextCandidateIndex(
-            IReadOnlyList<ReorderQueuePreviewItem> candidates,
-            ReorderQueuePreviewItem? previousItem,
-            int targetIndex,
-            int? maxMoveConstraint)
-        {
-            if (candidates.Count == 0)
-            {
-                return 0;
-            }
-
-            var fallbackIndex = -1;
-            for (var i = 0; i < candidates.Count; i++)
-            {
-                var candidate = candidates[i];
-                if (maxMoveConstraint.HasValue && Math.Abs(targetIndex - candidate.OriginalIndex) > maxMoveConstraint.Value)
-                {
-                    if (fallbackIndex == -1)
-                    {
-                        fallbackIndex = i;
-                    }
-                    continue;
-                }
-
-                if (previousItem != null &&
-                    !string.IsNullOrWhiteSpace(previousItem.Requestor) &&
-                    !string.IsNullOrWhiteSpace(candidate.Requestor) &&
-                    string.Equals(previousItem.Requestor, candidate.Requestor, StringComparison.OrdinalIgnoreCase))
-                {
-                    if (fallbackIndex == -1)
-                    {
-                        fallbackIndex = i;
-                    }
-                    continue;
-                }
-
-                return i;
-            }
-
-            if (fallbackIndex != -1)
-            {
-                return fallbackIndex;
-            }
-
-            return 0;
-        }
-
-        private List<ReorderQueuePreviewItem> PrioritizeItems(List<ReorderQueuePreviewItem> reorderableItems)
-        {
-            var sorted = reorderableItems
-                .OrderBy(item => item.IsMature && Mode == ReorderMode.DeferMature)
-                .ThenBy(item => item.DisplayIndex)
-                .ToList();
-
-            return sorted;
-        }
-
-        private static ReorderQueuePreviewItem CreateProposedItem(
-            ReorderQueuePreviewItem item,
-            int targetIndex,
-            IReadOnlyList<string> reasons,
-            bool isDeferred)
-        {
-            return item with
-            {
-                DisplayIndex = targetIndex,
-                Movement = targetIndex - item.OriginalIndex,
-                IsDeferred = isDeferred,
-                Reasons = reasons.ToArray()
-            };
-        }
-
-        private void FinalizePreviewMetadata(
-            IReadOnlyList<ReorderQueuePreviewItem> original,
-            IReadOnlyList<ReorderQueuePreviewItem> proposed,
-            int horizonCount)
-        {
-            PlanId = Guid.NewGuid().ToString("N");
+            PlanId = response.PlanId;
+            BasedOnVersion = response.BasedOnVersion;
+            ProposedVersion = response.ProposedVersion;
+            PlanExpiresAt = response.ExpiresAt;
             IdempotencyKey = Guid.NewGuid().ToString("N");
+
+            PopulateProposedItems(response.Items);
+            PopulateWarnings(response.Warnings);
+            PopulateDiffs(response.Diffs);
+
+            var summary = response.Summary;
+            MovedCount = summary.MoveCount;
+            FairnessBefore = summary.FairnessBefore;
+            FairnessAfter = summary.FairnessAfter;
+            NoAdjacentRepeat = summary.NoAdjacentRepeat;
+            _requiresConfirmation = summary.RequiresConfirmation || MovedCount >= _confirmationThreshold;
+
             IsPreviewGenerated = true;
-            PreviewStatus = "Preview generated. Review the proposed order before approving.";
-
-            FairnessBefore = CalculateFairness(original, horizonCount);
-            FairnessAfter = CalculateFairness(proposed, horizonCount);
-            NoAdjacentRepeat = CheckAdjacentRepeat(proposed);
-            MovedCount = proposed.Count(item => item.Movement != 0);
-
-            EvaluateWarnings();
+            PreviewStatus = PlanExpiresAt.HasValue
+                ? $"Preview ready. Plan expires at {PlanExpiresAt:HH:mm:ss}."
+                : "Preview generated.";
             UpdateApproveState();
         }
 
-        private static double CalculateFairness(
-            IReadOnlyList<ReorderQueuePreviewItem> items,
-            int horizonCount)
+        private void PopulateProposedItems(IEnumerable<ReorderQueuePreviewItem> items)
         {
-            if (items.Count == 0 || horizonCount <= 0)
+            ProposedItems.Clear();
+            foreach (var item in items.OrderBy(i => i.DisplayIndex))
             {
-                return 0;
+                ProposedItems.Add(item);
             }
-
-            horizonCount = Math.Min(horizonCount, items.Count);
-            var window = items.Take(horizonCount)
-                .Select(item => item.Requestor?.Trim())
-                .Where(name => !string.IsNullOrWhiteSpace(name))
-                .Select(name => name!.ToUpperInvariant())
-                .ToList();
-
-            if (window.Count == 0)
-            {
-                return 0;
-            }
-
-            var unique = window.Distinct().Count();
-            return Math.Round(unique / (double)window.Count, 2);
         }
 
-        private static bool CheckAdjacentRepeat(IEnumerable<ReorderQueuePreviewItem> items)
+        private void PopulateWarnings(IEnumerable<ReorderWarning> warnings)
         {
-            string? previous = null;
-            foreach (var item in items)
+            Warnings.Clear();
+            foreach (var warning in warnings ?? Enumerable.Empty<ReorderWarning>())
             {
-                var requestor = item.Requestor?.Trim();
-                if (!string.IsNullOrWhiteSpace(previous) &&
-                    !string.IsNullOrWhiteSpace(requestor) &&
-                    string.Equals(previous, requestor, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
+                var blocks = warning.BlocksApproval || string.Equals(warning.Code, AllMatureDeferredCode, StringComparison.OrdinalIgnoreCase);
+                Warnings.Add(blocks ? warning with { BlocksApproval = true } : warning);
+            }
+        }
 
-                if (!string.IsNullOrWhiteSpace(requestor))
-                {
-                    previous = requestor;
-                }
-                else
-                {
-                    previous = null;
-                }
+        private void PopulateDiffs(IEnumerable<ReorderPreviewDiff>? diffs)
+        {
+            Diffs.Clear();
+            if (diffs == null)
+            {
+                return;
             }
 
-            return true;
+            foreach (var diff in diffs)
+            {
+                Diffs.Add(diff);
+            }
+        }
+
+        partial void OnMovedCountChanged(int value)
+        {
+            UpdateApproveState();
         }
 
         [RelayCommand]
@@ -565,11 +401,7 @@ namespace BNKaraoke.DJ.ViewModels
                 return;
             }
 
-            var requiresConfirmation = MovedCount >= AreYouSureMoveThreshold
-                || ProposedItems.Any(item => Math.Abs(item.Movement) > LargeMoveDistanceThreshold)
-                || Mode == ReorderMode.AllowMature;
-
-            if (requiresConfirmation)
+            if (_requiresConfirmation)
             {
                 var result = MessageBox.Show(
                     "Are you sure you want to apply this reorder plan?",
@@ -594,44 +426,17 @@ namespace BNKaraoke.DJ.ViewModels
             RequestClose?.Invoke(this, false);
         }
 
-        private void EvaluateWarnings()
-        {
-            if (Mode == ReorderMode.DeferMature)
-            {
-                var reorderable = ProposedItems.Where(item => !item.IsLocked).ToList();
-                if (reorderable.Count > 0 && reorderable.All(item => item.IsDeferred || item.IsMature))
-                {
-                    AddWarning(new ReorderWarning(
-                        AllMatureDeferredCode,
-                        "All mature tracks are deferred. No playable songs remain within the selected horizon."));
-                }
-            }
-        }
-
-        private void AddWarning(ReorderWarning warning)
-        {
-            if (Warnings.All(existing => existing.Code != warning.Code))
-            {
-                Warnings.Add(warning);
-            }
-        }
-
-        partial void OnMovedCountChanged(int value)
-        {
-            UpdateApproveState();
-        }
-
         private void UpdateApproveState()
         {
-            IsApprovalBlocked = Warnings.Any(warning => warning.Code == AllMatureDeferredCode);
+            IsApprovalBlocked = Warnings.Any(warning => warning.BlocksApproval || string.Equals(warning.Code, AllMatureDeferredCode, StringComparison.OrdinalIgnoreCase));
 
-            var hasMeaningfulChanges = MovedCount > 0;
+            var hasMeaningfulChanges = IsPreviewGenerated && MovedCount > 0;
             if (IsPreviewGenerated && !hasMeaningfulChanges)
             {
                 PreviewStatus = "Preview matches the current queue. Reorder items before approving.";
             }
 
-            IsApproveEnabled = IsPreviewGenerated && !IsApprovalBlocked && hasMeaningfulChanges;
+            IsApproveEnabled = hasMeaningfulChanges && !IsApprovalBlocked && !IsBusy;
             OnPropertyChanged(nameof(AdjacentRepeatStatus));
         }
     }

--- a/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
+++ b/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
@@ -74,12 +74,12 @@
                     Visibility="{Binding HasWarnings, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <StackPanel>
                     <TextBlock Text="Warnings" FontWeight="Bold" Foreground="#1F2937" />
-                    <ItemsControl ItemsSource="{Binding WarningMessages}">
+                    <ItemsControl ItemsSource="{Binding Warnings}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                                     <TextBlock Text="•" Foreground="#1F2937" Margin="0,0,6,0" />
-                                    <TextBlock Text="{Binding}" Foreground="#1F2937" TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding Message}" Foreground="#1F2937" TextWrapping="Wrap" />
                                 </StackPanel>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -95,64 +95,76 @@
                 </Grid.ColumnDefinitions>
                 <StackPanel Grid.Column="0">
                     <TextBlock Text="Current order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
-                    <ListBox ItemsSource="{Binding CurrentItems}" Background="#111827" BorderBrush="#374151">
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            </Style>
-                        </ListBox.ItemContainerStyle>
-                        <ListBox.ItemTemplate>
-                            <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
-                                <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
-                                        ToolTipService.ToolTip="{Binding Tooltip}">
-                                    <StackPanel>
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
-                                            <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
-                                                    Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
-                                            </Border>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <ListBox ItemsSource="{Binding CurrentItems}" Background="#111827" BorderBrush="#374151"
+                                 ScrollViewer.CanContentScroll="True"
+                                 VirtualizingStackPanel.IsVirtualizing="True"
+                                 VirtualizingStackPanel.VirtualizationMode="Recycling"
+                                 VirtualizingPanel.ScrollUnit="Item">
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
+                                    <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
+                                            ToolTipService.ToolTip="{Binding Tooltip}">
+                                        <StackPanel>
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
+                                                <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                        Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
+                                                </Border>
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
                                         </StackPanel>
-                                        <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </ScrollViewer>
                 </StackPanel>
 
                 <Border Grid.Column="1" Width="24" />
 
                 <StackPanel Grid.Column="2">
                     <TextBlock Text="Proposed order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
-                    <ListBox ItemsSource="{Binding ProposedItems}" Background="#111827" BorderBrush="#374151">
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                            </Style>
-                        </ListBox.ItemContainerStyle>
-                        <ListBox.ItemTemplate>
-                            <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
-                                <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
-                                        ToolTipService.ToolTip="{Binding Tooltip}">
-                                    <StackPanel>
-                                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                            <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
-                                            <Border Background="#F97316" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
-                                                    Visibility="{Binding ShowMovement, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                <TextBlock Text="{Binding MovementDescription}" Foreground="White" FontSize="12" />
-                                            </Border>
-                                            <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
-                                                    Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
-                                            </Border>
+                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                        <ListBox ItemsSource="{Binding ProposedItems}" Background="#111827" BorderBrush="#374151"
+                                 ScrollViewer.CanContentScroll="True"
+                                 VirtualizingStackPanel.IsVirtualizing="True"
+                                 VirtualizingStackPanel.VirtualizationMode="Recycling"
+                                 VirtualizingPanel.ScrollUnit="Item">
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                </Style>
+                            </ListBox.ItemContainerStyle>
+                            <ListBox.ItemTemplate>
+                                <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
+                                    <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
+                                            ToolTipService.ToolTip="{Binding Tooltip}">
+                                        <StackPanel>
+                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
+                                                <Border Background="#F97316" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                        Visibility="{Binding ShowMovement, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock Text="{Binding MovementDescription}" Foreground="White" FontSize="12" />
+                                                </Border>
+                                                <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                        Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                    <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
+                                                </Border>
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
                                         </StackPanel>
-                                        <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
-                                    </StackPanel>
-                                </Border>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                                    </Border>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </ScrollViewer>
                 </StackPanel>
             </Grid>
 


### PR DESCRIPTION
## Summary
- add shared reorder DTOs and API exception wiring so the DJ client can call the queue preview and apply endpoints
- replace the modal's local heuristics with async preview requests that surface server metrics, warnings, and configuration defaults in the UI
- update the DJ screen approval flow and modal layout to consume the new plan metadata, handle conflicts, and virtualize both queue lists

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de7b78b8f883238353adf4580a16cd