### PR TITLE
Fix nested DJController helper types

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.Types.cs
+++ b/BNKaraoke.Api/Controllers/DJController.Types.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace BNKaraoke.Api.Controllers
+{
+    internal sealed class PreviewQueueState
+    {
+        public int QueueId { get; init; }
+        public int OriginalIndex { get; init; }
+        public int Position { get; init; }
+        public string RequestorUserName { get; init; } = string.Empty;
+        public string RequestorDisplayName { get; init; } = string.Empty;
+        public string SongTitle { get; init; } = string.Empty;
+        public string SongArtist { get; init; } = string.Empty;
+        public bool IsMature { get; init; }
+        public bool IsLocked { get; init; }
+        public int Movement { get; set; }
+        public bool IsDeferred { get; set; }
+        public int DisplayIndex { get; set; }
+        public List<string> Reasons { get; } = new();
+    }
+
+    internal sealed record PlanAssignmentDto(int QueueId, int Position);
+}

--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -44,25 +44,6 @@ namespace BNKaraoke.Api.Controllers
             PropertyNameCaseInsensitive = true
         };
 
-        private sealed class PreviewQueueState
-        {
-            public int QueueId { get; init; }
-            public int OriginalIndex { get; init; }
-            public int Position { get; init; }
-            public string RequestorUserName { get; init; } = string.Empty;
-            public string RequestorDisplayName { get; init; } = string.Empty;
-            public string SongTitle { get; init; } = string.Empty;
-            public string SongArtist { get; init; } = string.Empty;
-            public bool IsMature { get; init; }
-            public bool IsLocked { get; init; }
-            public int Movement { get; set; }
-            public bool IsDeferred { get; set; }
-            public int DisplayIndex { get; set; }
-            public List<string> Reasons { get; } = new();
-        }
-
-        private sealed record PlanAssignmentDto(int QueueId, int Position);
-
         public DJController(
             ApplicationDbContext context,
             ILogger<DJController> logger,


### PR DESCRIPTION
## Summary
- move PreviewQueueState and PlanAssignmentDto helper types to a dedicated file
- keep DJController unchanged apart from referencing the relocated helpers so the API build can resolve the types

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de81f7a1848323bc72de93e02c4dae