### PR TITLE
Fix placement of queue reorder endpoints in DJController

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -1522,38 +1522,39 @@ namespace BNKaraoke.Api.Controllers
                 return "Held";
             return "Unplayed";
         }
-    }
 
-    public class CheckInDto
-    {
-        public string RequestorUserName { get; set; } = string.Empty;
-    }
+        public class CheckInDto
+        {
+            public string RequestorUserName { get; set; } = string.Empty;
+        }
 
-    public class CompleteSongDto
-    {
-        public int EventId { get; set; }
-        public int QueueId { get; set; }
-    }
+        public class CompleteSongDto
+        {
+            public int EventId { get; set; }
+            public int QueueId { get; set; }
+        }
 
-    public class NowPlayingDto
-    {
-        public int QueueId { get; set; }
-    }
+        public class NowPlayingDto
+        {
+            public int QueueId { get; set; }
+        }
 
-    public class ToggleBreakDto
-    {
-        public int EventId { get; set; }
-        public int QueueId { get; set; }
-        public bool IsOnBreak { get; set; }
-    }
+        public class ToggleBreakDto
+        {
+            public int EventId { get; set; }
+            public int QueueId { get; set; }
+            public bool IsOnBreak { get; set; }
+        }
 
-    public class UpdateSingerStatusDto
-    {
-        public int EventId { get; set; }
-        public string RequestorUserName { get; set; } = string.Empty;
-        public bool IsLoggedIn { get; set; }
-        public bool IsJoined { get; set; }
-        public bool IsOnBreak { get; set; }
+        public class UpdateSingerStatusDto
+        {
+            public int EventId { get; set; }
+            public string RequestorUserName { get; set; } = string.Empty;
+            public bool IsLoggedIn { get; set; }
+            public bool IsJoined { get; set; }
+            public bool IsOnBreak { get; set; }
+
+        }
 
         [HttpPost("queue/reorder/preview")]
         public async Task<IActionResult> PreviewQueueReorder([FromBody] ReorderPreviewRequest request, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- keep the queue reorder endpoints inside DJController instead of the UpdateSingerStatusDto type
- restore the DTO definitions to be nested within DJController and ensure helper methods remain accessible

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de837bd0288323a40d753d3dbccaca