### PR TITLE
Broadcast queue reorder updates to clients

### DIFF
--- a/BNKaraoke.DJ/Models/QueueReorderAppliedMessage.cs
+++ b/BNKaraoke.DJ/Models/QueueReorderAppliedMessage.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace BNKaraoke.DJ.Models
+{
+    public class QueueReorderAppliedMessage
+    {
+        public int EventId { get; set; }
+        public string Version { get; set; } = string.Empty;
+        public string Mode { get; set; } = string.Empty;
+        public QueueReorderMetrics Metrics { get; set; } = new QueueReorderMetrics();
+        public List<QueueReorderOrderItem> Order { get; set; } = new List<QueueReorderOrderItem>();
+        public List<int> MovedQueueIds { get; set; } = new List<int>();
+    }
+
+    public class QueueReorderMetrics
+    {
+        public int MoveCount { get; set; }
+        public double FairnessBefore { get; set; }
+        public double FairnessAfter { get; set; }
+        public bool NoAdjacentRepeat { get; set; }
+        public bool RequiresConfirmation { get; set; }
+    }
+
+    public class QueueReorderOrderItem
+    {
+        public int QueueId { get; set; }
+        public int Position { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- emit a `queue/reorder_applied` SignalR payload when a reorder plan is applied so downstream clients receive the new order, metrics, and moved queue IDs
- add desktop client models and handlers to consume the new SignalR message, reorder the in-memory queue, and surface a move-count toast
- update the web SignalR hook to reconcile queue state against the server-provided order while keeping existing QueueUpdated handling intact

## Testing
- dotnet build BNKaraoke.sln *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de876cede08323af25480f00eac9eb