### PR TITLE
Ensure QueueReorderAudit audit IDs are generated

### DIFF
--- a/BNKaraoke.Api/Data/ApplicationDbContext.cs
+++ b/BNKaraoke.Api/Data/ApplicationDbContext.cs
@@ -461,7 +461,8 @@ namespace BNKaraoke.Api.Data
 
             modelBuilder.Entity<QueueReorderAudit>()
                 .Property(audit => audit.AuditId)
-                .HasColumnName("AuditId");
+                .HasColumnName("AuditId")
+                .ValueGeneratedOnAdd();
 
             modelBuilder.Entity<QueueReorderAudit>()
                 .Property(audit => audit.EventId)


### PR DESCRIPTION
## Summary
- mark the QueueReorderAudit primary key as database-generated so reorder preview audits persist correctly

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68deb2c67f248323967787aff715a4fb