### PR TITLE
Fix queue reorder audit identifier handling

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -1833,6 +1833,7 @@ namespace BNKaraoke.Api.Controllers
                 _context.QueueReorderPlans.Add(plan);
                 _context.QueueReorderAudits.Add(new QueueReorderAudit
                 {
+                    AuditId = Guid.NewGuid(),
                     EventId = request.EventId,
                     PlanId = plan.PlanId,
                     Action = "PREVIEW",
@@ -1978,6 +1979,7 @@ namespace BNKaraoke.Api.Controllers
 
                 _context.QueueReorderAudits.Add(new QueueReorderAudit
                 {
+                    AuditId = Guid.NewGuid(),
                     EventId = request.EventId,
                     PlanId = plan.PlanId,
                     Action = "APPLY",

--- a/BNKaraoke.Api/Data/ApplicationDbContext.cs
+++ b/BNKaraoke.Api/Data/ApplicationDbContext.cs
@@ -462,7 +462,8 @@ namespace BNKaraoke.Api.Data
             modelBuilder.Entity<QueueReorderAudit>()
                 .Property(audit => audit.AuditId)
                 .HasColumnName("AuditId")
-                .ValueGeneratedOnAdd();
+                .HasColumnType("uuid")
+                .ValueGeneratedNever();
 
             modelBuilder.Entity<QueueReorderAudit>()
                 .Property(audit => audit.EventId)

--- a/BNKaraoke.Api/Data/QueueReorder/QueueReorderAudit.cs
+++ b/BNKaraoke.Api/Data/QueueReorder/QueueReorderAudit.cs
@@ -4,7 +4,7 @@ namespace BNKaraoke.Api.Data.QueueReorder
 {
     public class QueueReorderAudit
     {
-        public long AuditId { get; set; }
+        public Guid AuditId { get; set; }
 
         public int EventId { get; set; }
 


### PR DESCRIPTION
## Summary
- align the queue reorder audit entity with the database by switching the primary key to a Guid
- update the EF Core model configuration to treat the audit identifier as a UUID and stop expecting database-generated values
- assign new audit identifiers when creating preview and apply audit records

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68deb451ae548323b0fc066fb8b2936c