### PR TITLE
Fix queue reorder fairness when head entries are locked

### DIFF
--- a/BNKaraoke.Api.Tests/Unit/CpSatQueueOptimizerTests.cs
+++ b/BNKaraoke.Api.Tests/Unit/CpSatQueueOptimizerTests.cs
@@ -20,10 +20,10 @@ public class CpSatQueueOptimizerTests
 
         var items = new List<QueueOptimizerItem>
         {
-            new(1, 0, "A", false, 0),
-            new(2, 1, "A", false, 1),
-            new(3, 2, "B", false, 0),
-            new(4, 3, "C", false, 0)
+            new(1, 0, "A", false, 0, 0, null),
+            new(2, 1, "A", false, 1, 1, 0),
+            new(3, 2, "B", false, 0, 2, null),
+            new(4, 3, "C", false, 0, 3, null)
         };
 
         var request = new QueueOptimizerRequest(
@@ -32,7 +32,8 @@ public class CpSatQueueOptimizerTests
             MovementCap: null,
             SolverMaxTimeMilliseconds: 2000,
             RandomSeed: 1,
-            NumSearchWorkers: 1);
+            NumSearchWorkers: 1,
+            LockedHeadCount: 0);
 
         var result = await optimizer.OptimizeAsync(request);
 

--- a/BNKaraoke.Api/Services/QueueReorder/IQueueOptimizer.cs
+++ b/BNKaraoke.Api/Services/QueueReorder/IQueueOptimizer.cs
@@ -16,14 +16,17 @@ namespace BNKaraoke.Api.Services.QueueReorder
         int? MovementCap,
         int SolverMaxTimeMilliseconds,
         int? RandomSeed,
-        int NumSearchWorkers);
+        int NumSearchWorkers,
+        int LockedHeadCount);
 
     public record QueueOptimizerItem(
         int QueueId,
         int OriginalIndex,
         string RequestorUserName,
         bool IsMature,
-        int HistoricalCount);
+        int HistoricalCount,
+        int AbsoluteOriginalIndex,
+        int? PreviousAbsoluteIndex);
 
     public record QueueReorderAssignment(int QueueId, int ProposedIndex);
 


### PR DESCRIPTION
## Summary
- include locked-head singer history when building queue optimizer inputs so the solver can separate repeated singers
- extend the CP-SAT optimizer to enforce spacing against both relative and absolute singer positions and surface clearer reasons
- add regression coverage ensuring singers after a locked head entry are moved back to avoid consecutive turns

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ded84b19cc832395b113f8dda0f82c