### PR TITLE
Improve queue optimizer singer spacing

### DIFF
--- a/BNKaraoke.Api.Tests/Unit/CpSatQueueOptimizerTests.cs
+++ b/BNKaraoke.Api.Tests/Unit/CpSatQueueOptimizerTests.cs
@@ -57,4 +57,81 @@ public class CpSatQueueOptimizerTests
         var reasons = result.Items.Single(i => i.QueueId == 2).Reasons;
         reasons.Should().Contain(reason => reason.Contains("avoid back-to-back", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public async Task OptimizeAsync_SeparatesMultipleOccurrencesWhenAlternativesExist()
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+        var optimizer = new CpSatQueueOptimizer(loggerFactory.CreateLogger<CpSatQueueOptimizer>());
+
+        var items = new List<QueueOptimizerItem>
+        {
+            new(1, 0, "A", false, 0, 0, null),
+            new(2, 1, "A", false, 1, 1, 0),
+            new(3, 2, "B", false, 0, 2, null),
+            new(4, 3, "A", false, 2, 3, 1),
+            new(5, 4, "C", false, 0, 4, null)
+        };
+
+        var request = new QueueOptimizerRequest(
+            items,
+            QueueReorderMaturePolicy.Allow,
+            MovementCap: null,
+            SolverMaxTimeMilliseconds: 2000,
+            RandomSeed: 1,
+            NumSearchWorkers: 1,
+            LockedHeadCount: 0);
+
+        var result = await optimizer.OptimizeAsync(request);
+
+        result.IsFeasible.Should().BeTrue();
+        result.IsNoOp.Should().BeFalse();
+
+        var orderedItems = result.Assignments
+            .OrderBy(a => a.ProposedIndex)
+            .Select(a => items.First(i => i.QueueId == a.QueueId))
+            .ToList();
+
+        for (var i = 1; i < orderedItems.Count; i++)
+        {
+            var current = orderedItems[i];
+            var previous = orderedItems[i - 1];
+            if (!string.Equals(current.RequestorUserName, "A", StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(previous.RequestorUserName, "A", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            Assert.True(false, "Adjacent entries for singer A were not separated.");
+        }
+    }
+
+    [Fact]
+    public async Task OptimizeAsync_AllowsAdjacencyWhenInsufficientAlternatives()
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => { });
+        var optimizer = new CpSatQueueOptimizer(loggerFactory.CreateLogger<CpSatQueueOptimizer>());
+
+        var items = new List<QueueOptimizerItem>
+        {
+            new(1, 0, "A", false, 0, 0, null),
+            new(2, 1, "A", false, 1, 1, 0),
+            new(3, 2, "A", false, 2, 2, 1),
+            new(4, 3, "B", false, 0, 3, null)
+        };
+
+        var request = new QueueOptimizerRequest(
+            items,
+            QueueReorderMaturePolicy.Allow,
+            MovementCap: null,
+            SolverMaxTimeMilliseconds: 2000,
+            RandomSeed: 1,
+            NumSearchWorkers: 1,
+            LockedHeadCount: 0);
+
+        var result = await optimizer.OptimizeAsync(request);
+
+        result.IsFeasible.Should().BeTrue();
+        result.IsNoOp.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- add singer index tracking in the CP-SAT optimizer so it can require at least one other singer between repeated performers when enough alternatives are present
- extend queue optimizer unit coverage to ensure repeated singers are separated when possible and still feasible when alternatives are limited

## Testing
- dotnet test *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dedcd649988323a19df9d55ea5f1b2