### PR TITLE
Improve reorder modal layout

### DIFF
--- a/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
+++ b/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Title="Reorder Queue"
         Width="900"
-        Height="640"
+        Height="820"
         WindowStartupLocation="CenterOwner"
         ResizeMode="NoResize"
         ShowInTaskbar="False"
@@ -69,8 +69,14 @@
             </Grid>
         </Border>
 
-        <StackPanel Grid.Row="2" Margin="0,16,0,0">
-            <Border Background="#FBBF24" Padding="12" CornerRadius="6" Margin="0,0,0,12"
+        <Grid Grid.Row="2" Margin="0,16,0,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0" Background="#FBBF24" Padding="12" CornerRadius="6" Margin="0,0,0,12"
                     Visibility="{Binding HasWarnings, Converter={StaticResource BooleanToVisibilityConverter}}">
                 <StackPanel>
                     <TextBlock Text="Warnings" FontWeight="Bold" Foreground="#1F2937" />
@@ -87,16 +93,19 @@
                 </StackPanel>
             </Border>
 
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                    <ColumnDefinition Width="*" />
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0">
-                    <TextBlock Text="Current order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+
+                    <StackPanel Grid.Column="0">
+                        <TextBlock Text="Current order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
                         <ListBox ItemsSource="{Binding CurrentItems}" Background="#111827" BorderBrush="#374151"
+                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                  ScrollViewer.CanContentScroll="True"
                                  VirtualizingStackPanel.IsVirtualizing="True"
                                  VirtualizingStackPanel.VirtualizationMode="Recycling"
@@ -124,15 +133,15 @@
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
-                    </ScrollViewer>
-                </StackPanel>
+                    </StackPanel>
 
-                <Border Grid.Column="1" Width="24" />
+                    <Border Grid.Column="1" Width="24" />
 
-                <StackPanel Grid.Column="2">
-                    <TextBlock Text="Proposed order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
-                    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel Grid.Column="2">
+                        <TextBlock Text="Proposed order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
                         <ListBox ItemsSource="{Binding ProposedItems}" Background="#111827" BorderBrush="#374151"
+                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                                  ScrollViewer.CanContentScroll="True"
                                  VirtualizingStackPanel.IsVirtualizing="True"
                                  VirtualizingStackPanel.VirtualizationMode="Recycling"
@@ -164,12 +173,12 @@
                                 </DataTemplate>
                             </ListBox.ItemTemplate>
                         </ListBox>
-                    </ScrollViewer>
-                </StackPanel>
-            </Grid>
+                    </StackPanel>
+                </Grid>
+            </ScrollViewer>
 
-            <TextBlock Text="{Binding PreviewStatus}" Foreground="#9CA3AF" Margin="0,12,0,0" TextWrapping="Wrap" />
-        </StackPanel>
+            <TextBlock Grid.Row="2" Text="{Binding PreviewStatus}" Foreground="#9CA3AF" Margin="0,12,0,0" TextWrapping="Wrap" />
+        </Grid>
 
         <Border Grid.Row="3" Background="#1F2937" CornerRadius="6" Padding="12" Margin="0,16,0,0">
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">


### PR DESCRIPTION
## Summary
- increase the Reorder Queue modal height for better preview visibility
- restructure the current/proposed list section to share a single vertical scrollbar so both sides scroll together

## Testing
- dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj *(fails: `dotnet` not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df02a448188323acaeacfc0582a4eb