### PR TITLE
Show message when queue recommendations unchanged

### DIFF
--- a/BNKaraoke.DJ/ViewModels/ReorderQueueModalViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/ReorderQueueModalViewModel.cs
@@ -110,6 +110,10 @@ namespace BNKaraoke.DJ.ViewModels
 
         public string AdjacentRepeatStatus => NoAdjacentRepeat ? "✓" : "✗";
 
+        public bool HasRecommendedChanges => ProposedItems.Any(item => item.ShowMovement);
+
+        public bool ShowNoRecommendationsMessage => IsPreviewGenerated && !HasRecommendedChanges;
+
         public ReorderQueueModalViewModel(
             IApiService apiService,
             SettingsService settingsService,
@@ -137,6 +141,7 @@ namespace BNKaraoke.DJ.ViewModels
             ConfigureDefaultMatureMode(_settingsService.Settings.DefaultReorderMaturePolicy);
 
             Warnings.CollectionChanged += Warnings_CollectionChanged;
+            ProposedItems.CollectionChanged += ProposedItems_CollectionChanged;
             UpdateApproveState();
         }
 
@@ -159,6 +164,12 @@ namespace BNKaraoke.DJ.ViewModels
             OnPropertyChanged(nameof(WarningMessages));
             OnPropertyChanged(nameof(HasWarnings));
             UpdateApproveState();
+        }
+
+        private void ProposedItems_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(HasRecommendedChanges));
+            OnPropertyChanged(nameof(ShowNoRecommendationsMessage));
         }
 
         partial void OnIsDeferMatureChanged(bool value)
@@ -211,6 +222,11 @@ namespace BNKaraoke.DJ.ViewModels
 
             OnPropertyChanged(nameof(MaxMoveConstraint));
             InvalidatePreview();
+        }
+
+        partial void OnIsPreviewGeneratedChanged(bool value)
+        {
+            OnPropertyChanged(nameof(ShowNoRecommendationsMessage));
         }
 
         private void InvalidatePreview()

--- a/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
+++ b/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
@@ -139,40 +139,48 @@
 
                     <StackPanel Grid.Column="2">
                         <TextBlock Text="Proposed order" FontSize="16" FontWeight="Bold" Foreground="White" Margin="0,0,0,8" />
-                        <ListBox ItemsSource="{Binding ProposedItems}" Background="#111827" BorderBrush="#374151"
-                                 ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                 ScrollViewer.CanContentScroll="True"
-                                 VirtualizingStackPanel.IsVirtualizing="True"
-                                 VirtualizingStackPanel.VirtualizationMode="Recycling"
-                                 VirtualizingPanel.ScrollUnit="Item">
-                            <ListBox.ItemContainerStyle>
-                                <Style TargetType="ListBoxItem">
-                                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                                </Style>
-                            </ListBox.ItemContainerStyle>
-                            <ListBox.ItemTemplate>
-                                <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
-                                    <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
-                                            ToolTipService.ToolTip="{Binding Tooltip}">
-                                        <StackPanel>
-                                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
-                                                <Border Background="#F97316" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
-                                                        Visibility="{Binding ShowMovement, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                    <TextBlock Text="{Binding MovementDescription}" Foreground="White" FontSize="12" />
-                                                </Border>
-                                                <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
-                                                        Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
-                                                    <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
-                                                </Border>
+                        <Grid>
+                            <ListBox ItemsSource="{Binding ProposedItems}" Background="#111827" BorderBrush="#374151"
+                                     ScrollViewer.VerticalScrollBarVisibility="Disabled"
+                                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                     ScrollViewer.CanContentScroll="True"
+                                     VirtualizingStackPanel.IsVirtualizing="True"
+                                     VirtualizingStackPanel.VirtualizationMode="Recycling"
+                                     VirtualizingPanel.ScrollUnit="Item">
+                                <ListBox.ItemContainerStyle>
+                                    <Style TargetType="ListBoxItem">
+                                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                    </Style>
+                                </ListBox.ItemContainerStyle>
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate DataType="{x:Type models:ReorderQueuePreviewItem}">
+                                        <Border Background="#1F2937" CornerRadius="6" Padding="10" Margin="0,0,0,8"
+                                                ToolTipService.ToolTip="{Binding Tooltip}">
+                                            <StackPanel>
+                                                <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                                    <TextBlock Text="{Binding DisplayLabel}" FontWeight="SemiBold" Foreground="White" />
+                                                    <Border Background="#F97316" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                            Visibility="{Binding ShowMovement, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                        <TextBlock Text="{Binding MovementDescription}" Foreground="White" FontSize="12" />
+                                                    </Border>
+                                                    <Border Background="#7C3AED" CornerRadius="4" Padding="4,2" Margin="8,0,0,0"
+                                                            Visibility="{Binding ShowMaturePill, Converter={StaticResource BooleanToVisibilityConverter}}">
+                                                        <TextBlock Text="{Binding MaturePillText}" Foreground="White" FontSize="12" />
+                                                    </Border>
+                                                </StackPanel>
+                                                <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
                                             </StackPanel>
-                                            <TextBlock Text="{Binding SecondaryLine}" Foreground="#D1D5DB" Margin="0,4,0,0" />
-                                        </StackPanel>
-                                    </Border>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
+                                        </Border>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <Border Background="#111827" Opacity="0.95" CornerRadius="6" IsHitTestVisible="False"
+                                    Visibility="{Binding ShowNoRecommendationsMessage, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                <TextBlock Text="No Changes Recommended" Foreground="#9CA3AF" FontSize="16" FontWeight="SemiBold"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+                            </Border>
+                        </Grid>
                     </StackPanel>
                 </Grid>
             </ScrollViewer>


### PR DESCRIPTION
## Summary
- add view-model state to detect when the reorder preview does not move any items
- overlay a "No Changes Recommended" message on the proposed order list when no movements are suggested

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68df06cbbe208323a1910580379ad85f