### PR TITLE
Highlight approve button when reorder changes exist

### DIFF
--- a/BNKaraoke.DJ/Services/IUserSessionService.cs
+++ b/BNKaraoke.DJ/Services/IUserSessionService.cs
@@ -11,8 +11,10 @@ namespace BNKaraoke.DJ.Services
         string? FirstName { get; }
         string? UserName { get; }
         List<string>? Roles { get; }
+        ReorderMode? PreferredReorderMode { get; }
         event EventHandler SessionChanged;
         void SetSession(LoginResult loginResult, string userName);
+        void SetPreferredReorderMode(ReorderMode mode);
         void ClearSession();
     }
 }

--- a/BNKaraoke.DJ/Services/UserSessionService.cs
+++ b/BNKaraoke.DJ/Services/UserSessionService.cs
@@ -17,6 +17,7 @@ namespace BNKaraoke.DJ.Services
         public string? FirstName { get; private set; }
         public string? UserName { get; private set; }
         public List<string>? Roles { get; private set; }
+        public ReorderMode? PreferredReorderMode { get; private set; }
 
         private UserSessionService()
         {
@@ -54,6 +55,7 @@ namespace BNKaraoke.DJ.Services
                 UserName = null;
                 Roles = null;
                 IsAuthenticated = false;
+                PreferredReorderMode = null;
                 SessionChanged?.Invoke(this, EventArgs.Empty);
                 Log.Information("[SESSION] Session cleared: IsAuthenticated={IsAuthenticated}", IsAuthenticated);
             }
@@ -61,6 +63,11 @@ namespace BNKaraoke.DJ.Services
             {
                 Log.Error("[SESSION] Failed to clear session: {Message}", ex.Message);
             }
+        }
+
+        public void SetPreferredReorderMode(ReorderMode mode)
+        {
+            PreferredReorderMode = mode;
         }
     }
 }

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Queue.cs
@@ -159,7 +159,7 @@ namespace BNKaraoke.DJ.ViewModels
                     return;
                 }
 
-                var modalViewModel = new ReorderQueueModalViewModel(_apiService, _settingsService, eventId, snapshot);
+                var modalViewModel = new ReorderQueueModalViewModel(_apiService, _settingsService, _userSessionService, eventId, snapshot);
                 var modal = new ReorderQueueModal
                 {
                     Owner = Application.Current.Windows.OfType<DJScreen>().FirstOrDefault(),

--- a/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
+++ b/BNKaraoke.DJ/Views/ReorderQueueModal.xaml
@@ -206,7 +206,18 @@
                 <TextBlock Text="All mature tracks are deferred. Approve is disabled." Foreground="#1F2937" FontWeight="SemiBold" />
             </Border>
             <Button Content="Approve" Command="{Binding ApproveCommand}" Width="120" Height="36" Margin="0,0,12,0"
-                    IsEnabled="{Binding IsApproveEnabled}" />
+                    IsEnabled="{Binding IsApproveEnabled}">
+                <Button.Style>
+                    <Style TargetType="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsApproveEnabled}" Value="True">
+                                <Setter Property="Background" Value="#FF0000" />
+                                <Setter Property="Foreground" Value="Black" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
             <Button Content="Cancel" Command="{Binding CancelCommand}" Width="120" Height="36" IsCancel="True" />
         </StackPanel>
     </Grid>


### PR DESCRIPTION
## Summary
- highlight the reorder modal Approve button in red with black text when a preview can be applied
- persist the selected reorder mature mode in the user session so it remains set until logout and defaults to Defer on first open

## Testing
- Not Run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df0a5789c08323ba6e3af6f55a68be