### PR TITLE
Handle null requestor names when building queue optimizer items

### DIFF
--- a/BNKaraoke.Api/Controllers/DJController.cs
+++ b/BNKaraoke.Api/Controllers/DJController.cs
@@ -1704,6 +1704,7 @@ namespace BNKaraoke.Api.Controllers
                         continue;
                     }
 
+                    var requestorUserName = item.RequestorUserName ?? string.Empty;
                     var historicalCount = previewItems
                         .Take(item.OriginalIndex)
                         .Count(p => string.Equals(p.RequestorUserName, item.RequestorUserName, StringComparison.OrdinalIgnoreCase));
@@ -1711,7 +1712,7 @@ namespace BNKaraoke.Api.Controllers
                     optimizerItems.Add(new QueueOptimizerItem(
                         item.QueueId,
                         optimizerItems.Count,
-                        item.RequestorUserName,
+                        requestorUserName,
                         item.IsMature,
                         historicalCount,
                         item.OriginalIndex,


### PR DESCRIPTION
## Summary
- default queue optimizer items to use an empty requestor name when the preview entry lacks one to avoid null arguments

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfbb328bf4832387415ab01f4ee6d6