### PR TITLE
Refine overlay bands to reuse existing blue screen

### DIFF
--- a/BNKaraoke.DJ/Models/DjSettings.cs
+++ b/BNKaraoke.DJ/Models/DjSettings.cs
@@ -27,5 +27,6 @@ namespace BNKaraoke.DJ.Models
         public bool EnableAudioEngineRestartButton { get; set; } = true;
         public string DefaultReorderMaturePolicy { get; set; } = "Defer";
         public int QueueReorderConfirmationThreshold { get; set; } = 6;
+        public OverlaySettings Overlay { get; set; } = new OverlaySettings();
     }
 }

--- a/BNKaraoke.DJ/Models/OverlaySettings.cs
+++ b/BNKaraoke.DJ/Models/OverlaySettings.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace BNKaraoke.DJ.Models
+{
+    public class OverlaySettings
+    {
+        public bool EnabledTop { get; set; } = true;
+        public bool EnabledBottom { get; set; } = true;
+        public double TopHeightPercent { get; set; } = 0.10;
+        public double BottomHeightPercent { get; set; } = 0.10;
+        public double BackgroundOpacity { get; set; } = 0.25;
+        public bool UseGradient { get; set; } = true;
+        public string PrimaryColor { get; set; } = "#1e3a8a";
+        public string SecondaryColor { get; set; } = "#3b82f6";
+        public string Brand { get; set; } = "BNKaraoke.com";
+
+        public void Clamp()
+        {
+            TopHeightPercent = ClampPercent(TopHeightPercent);
+            BottomHeightPercent = ClampPercent(BottomHeightPercent);
+            BackgroundOpacity = Math.Clamp(BackgroundOpacity, 0.0, 1.0);
+        }
+
+        private static double ClampPercent(double value)
+        {
+            return double.IsFinite(value) ? Math.Clamp(value, 0.0, 1.0) : 0.0;
+        }
+    }
+}

--- a/BNKaraoke.DJ/Services/SettingsService.cs
+++ b/BNKaraoke.DJ/Services/SettingsService.cs
@@ -51,6 +51,11 @@ namespace BNKaraoke.DJ.Services
                             settings.ApiUrl = "https://api.bnkaraoke.com";
                             SaveSettings(settings);
                         }
+                        if (settings.Overlay == null)
+                        {
+                            settings.Overlay = new OverlaySettings();
+                        }
+                        settings.Overlay.Clamp();
                         if (string.IsNullOrWhiteSpace(settings.AudioOutputModule))
                         {
                             settings.AudioOutputModule = "mmdevice";
@@ -90,7 +95,8 @@ namespace BNKaraoke.DJ.Services
                 MaximizedOnStart = true,
                 LogFilePath = @"C:\BNKaraoke_Logs\DJ.log",
                 EnableVerboseLogging = true,
-                TestMode = false
+                TestMode = false,
+                Overlay = new OverlaySettings()
             };
             SaveSettings(defaultSettings);
             Log.Information("[SETTINGS SERVICE] Created default settings at {Path}", _settingsPath);
@@ -117,6 +123,8 @@ namespace BNKaraoke.DJ.Services
                 }
                 settings.PreferredAudioDevice = NormalizePreferredAudioDevice(settings.PreferredAudioDevice);
                 settings.AudioOutputModule = string.IsNullOrWhiteSpace(settings.AudioOutputModule) ? "mmdevice" : settings.AudioOutputModule;
+                settings.Overlay ??= new OverlaySettings();
+                settings.Overlay.Clamp();
                 var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
                 File.WriteAllText(_settingsPath, json);
                 var previousAudioDevice = Settings?.PreferredAudioDevice;

--- a/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
@@ -1,0 +1,354 @@
+using BNKaraoke.DJ.Models;
+using BNKaraoke.DJ.Services;
+using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace BNKaraoke.DJ.ViewModels.Overlays
+{
+    public class OverlayViewModel : ViewModels.ViewModelBase
+    {
+        private static readonly Lazy<OverlayViewModel> _instance = new(() => new OverlayViewModel());
+        public static OverlayViewModel Instance => _instance.Value;
+
+        private readonly SettingsService _settingsService = SettingsService.Instance;
+        private bool _suppressSave;
+
+        private bool _isTopEnabled;
+        private bool _isBottomEnabled;
+        private double _topHeightPercent;
+        private double _bottomHeightPercent;
+        private double _backgroundOpacity;
+        private bool _useGradient;
+        private string _primaryColor = "#1e3a8a";
+        private string _secondaryColor = "#3b82f6";
+        private string _brand = "BNKaraoke.com";
+        private Brush _topBandBrush = Brushes.Transparent;
+        private Brush _bottomBandBrush = Brushes.Transparent;
+
+        private OverlayViewModel()
+        {
+            ApplySettings(_settingsService.Settings.Overlay ?? new OverlaySettings());
+        }
+
+        public bool IsTopEnabled
+        {
+            get => _isTopEnabled;
+            set
+            {
+                if (_isTopEnabled != value)
+                {
+                    _isTopEnabled = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(TopBandVisibility));
+                    OnPropertyChanged(nameof(TopRowHeight));
+                    OnPropertyChanged(nameof(CenterRowHeight));
+                    Persist();
+                }
+            }
+        }
+
+        public bool IsBottomEnabled
+        {
+            get => _isBottomEnabled;
+            set
+            {
+                if (_isBottomEnabled != value)
+                {
+                    _isBottomEnabled = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(BottomBandVisibility));
+                    OnPropertyChanged(nameof(BottomRowHeight));
+                    OnPropertyChanged(nameof(CenterRowHeight));
+                    Persist();
+                }
+            }
+        }
+
+        public double TopHeightPercent
+        {
+            get => _topHeightPercent;
+            set
+            {
+                value = ClampPercent(value);
+                if (!value.Equals(_topHeightPercent))
+                {
+                    _topHeightPercent = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(TopRowHeight));
+                    OnPropertyChanged(nameof(CenterRowHeight));
+                    Persist();
+                }
+            }
+        }
+
+        public double BottomHeightPercent
+        {
+            get => _bottomHeightPercent;
+            set
+            {
+                value = ClampPercent(value);
+                if (!value.Equals(_bottomHeightPercent))
+                {
+                    _bottomHeightPercent = value;
+                    OnPropertyChanged();
+                    OnPropertyChanged(nameof(BottomRowHeight));
+                    OnPropertyChanged(nameof(CenterRowHeight));
+                    Persist();
+                }
+            }
+        }
+
+        public double BackgroundOpacity
+        {
+            get => _backgroundOpacity;
+            set
+            {
+                value = Math.Clamp(value, 0.0, 1.0);
+                if (!value.Equals(_backgroundOpacity))
+                {
+                    _backgroundOpacity = value;
+                    OnPropertyChanged();
+                    UpdateBrushes();
+                    Persist();
+                }
+            }
+        }
+
+        public bool UseGradient
+        {
+            get => _useGradient;
+            set
+            {
+                if (_useGradient != value)
+                {
+                    _useGradient = value;
+                    OnPropertyChanged();
+                    UpdateBrushes();
+                    Persist();
+                }
+            }
+        }
+
+        public string PrimaryColor
+        {
+            get => _primaryColor;
+            set
+            {
+                if (!string.Equals(_primaryColor, value, StringComparison.OrdinalIgnoreCase))
+                {
+                    _primaryColor = value ?? _primaryColor;
+                    OnPropertyChanged();
+                    UpdateBrushes();
+                    Persist();
+                }
+            }
+        }
+
+        public string SecondaryColor
+        {
+            get => _secondaryColor;
+            set
+            {
+                if (!string.Equals(_secondaryColor, value, StringComparison.OrdinalIgnoreCase))
+                {
+                    _secondaryColor = value ?? _secondaryColor;
+                    OnPropertyChanged();
+                    UpdateBrushes();
+                    Persist();
+                }
+            }
+        }
+
+        public string Brand
+        {
+            get => _brand;
+            set
+            {
+                if (!string.Equals(_brand, value, StringComparison.Ordinal))
+                {
+                    _brand = value ?? string.Empty;
+                    OnPropertyChanged();
+                    Persist();
+                }
+            }
+        }
+
+        public Brush TopBandBrush
+        {
+            get => _topBandBrush;
+            private set
+            {
+                if (!ReferenceEquals(_topBandBrush, value))
+                {
+                    _topBandBrush = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public Brush BottomBandBrush
+        {
+            get => _bottomBandBrush;
+            private set
+            {
+                if (!ReferenceEquals(_bottomBandBrush, value))
+                {
+                    _bottomBandBrush = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public Visibility TopBandVisibility => IsTopEnabled ? Visibility.Visible : Visibility.Collapsed;
+
+        public Visibility BottomBandVisibility => IsBottomEnabled ? Visibility.Visible : Visibility.Collapsed;
+
+        public GridLength TopRowHeight => IsTopEnabled ? new GridLength(TopHeightPercent, GridUnitType.Star) : new GridLength(0);
+
+        public GridLength BottomRowHeight => IsBottomEnabled ? new GridLength(BottomHeightPercent, GridUnitType.Star) : new GridLength(0);
+
+        public GridLength CenterRowHeight
+        {
+            get
+            {
+                var top = IsTopEnabled ? TopHeightPercent : 0.0;
+                var bottom = IsBottomEnabled ? BottomHeightPercent : 0.0;
+                var remaining = Math.Max(1.0 - (top + bottom), 0.0001);
+                return new GridLength(remaining, GridUnitType.Star);
+            }
+        }
+
+        public void RefreshFromSettings()
+        {
+            ApplySettings(_settingsService.Settings.Overlay ?? new OverlaySettings());
+        }
+
+        private void ApplySettings(OverlaySettings settings)
+        {
+            settings.Clamp();
+            _suppressSave = true;
+
+            _isTopEnabled = settings.EnabledTop;
+            _isBottomEnabled = settings.EnabledBottom;
+            _topHeightPercent = settings.TopHeightPercent;
+            _bottomHeightPercent = settings.BottomHeightPercent;
+            _backgroundOpacity = settings.BackgroundOpacity;
+            _useGradient = settings.UseGradient;
+            _primaryColor = settings.PrimaryColor ?? _primaryColor;
+            _secondaryColor = settings.SecondaryColor ?? _secondaryColor;
+            _brand = settings.Brand ?? string.Empty;
+
+            OnPropertyChanged(nameof(IsTopEnabled));
+            OnPropertyChanged(nameof(IsBottomEnabled));
+            OnPropertyChanged(nameof(TopHeightPercent));
+            OnPropertyChanged(nameof(BottomHeightPercent));
+            OnPropertyChanged(nameof(BackgroundOpacity));
+            OnPropertyChanged(nameof(UseGradient));
+            OnPropertyChanged(nameof(PrimaryColor));
+            OnPropertyChanged(nameof(SecondaryColor));
+            OnPropertyChanged(nameof(Brand));
+            OnPropertyChanged(nameof(TopBandVisibility));
+            OnPropertyChanged(nameof(BottomBandVisibility));
+            OnPropertyChanged(nameof(TopRowHeight));
+            OnPropertyChanged(nameof(BottomRowHeight));
+            OnPropertyChanged(nameof(CenterRowHeight));
+
+            UpdateBrushes();
+
+            _suppressSave = false;
+        }
+
+        private void UpdateBrushes()
+        {
+            TopBandBrush = CreateBrush(isTop: true);
+            BottomBandBrush = CreateBrush(isTop: false);
+        }
+
+        private Brush CreateBrush(bool isTop)
+        {
+            var primary = ParseColor(PrimaryColor, Color.FromRgb(30, 58, 138));
+            var secondary = ParseColor(SecondaryColor, Color.FromRgb(59, 130, 246));
+            if (!UseGradient)
+            {
+                var color = WithOpacity(isTop ? primary : secondary, BackgroundOpacity);
+                var solid = new SolidColorBrush(color);
+                solid.Freeze();
+                return solid;
+            }
+
+            var brush = new LinearGradientBrush
+            {
+                StartPoint = new Point(0, isTop ? 0 : 1),
+                EndPoint = new Point(0, isTop ? 1 : 0)
+            };
+            brush.GradientStops.Add(new GradientStop(WithOpacity(primary, BackgroundOpacity), 0));
+            brush.GradientStops.Add(new GradientStop(WithOpacity(secondary, BackgroundOpacity), 1));
+            brush.Freeze();
+            return brush;
+        }
+
+        private void Persist()
+        {
+            if (_suppressSave)
+            {
+                return;
+            }
+
+            var settings = _settingsService.Settings;
+            settings.Overlay ??= new OverlaySettings();
+            settings.Overlay.EnabledTop = IsTopEnabled;
+            settings.Overlay.EnabledBottom = IsBottomEnabled;
+            settings.Overlay.TopHeightPercent = TopHeightPercent;
+            settings.Overlay.BottomHeightPercent = BottomHeightPercent;
+            settings.Overlay.BackgroundOpacity = BackgroundOpacity;
+            settings.Overlay.UseGradient = UseGradient;
+            settings.Overlay.PrimaryColor = PrimaryColor;
+            settings.Overlay.SecondaryColor = SecondaryColor;
+            settings.Overlay.Brand = Brand;
+
+            _settingsService.Save();
+        }
+
+        private static double ClampPercent(double value)
+        {
+            if (!double.IsFinite(value))
+            {
+                return 0.0;
+            }
+
+            return Math.Clamp(value, 0.0, 1.0);
+        }
+
+        private static Color ParseColor(string color, Color fallback)
+        {
+            if (string.IsNullOrWhiteSpace(color))
+            {
+                return fallback;
+            }
+
+            try
+            {
+                var converter = new ColorConverter();
+                var converted = converter.ConvertFromString(color) as Color?;
+                if (converted.HasValue)
+                {
+                    return converted.Value;
+                }
+            }
+            catch
+            {
+                // Ignore and use fallback
+            }
+
+            return fallback;
+        }
+
+        private static Color WithOpacity(Color color, double opacity)
+        {
+            opacity = Math.Clamp(opacity, 0.0, 1.0);
+            byte alpha = (byte)Math.Round(opacity * 255);
+            return Color.FromArgb(alpha, color.R, color.G, color.B);
+        }
+    }
+}

--- a/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml
+++ b/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml
@@ -1,0 +1,25 @@
+<UserControl x:Class="BNKaraoke.DJ.Views.Overlays.OverlayBand"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             d:DesignHeight="120"
+             d:DesignWidth="800"
+             Focusable="False"
+             IsTabStop="False"
+             UseLayoutRounding="True"
+             SnapsToDevicePixels="True"
+             Padding="32,24">
+    <Grid Background="{Binding Background, RelativeSource={RelativeSource AncestorType=UserControl}}"
+          Padding="{Binding Padding, RelativeSource={RelativeSource AncestorType=UserControl}}"
+          HorizontalAlignment="Stretch"
+          VerticalAlignment="Stretch"
+          SnapsToDevicePixels="True">
+        <ContentPresenter HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          Content="{Binding Content, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                          ContentTemplate="{Binding ContentTemplate, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                          ContentTemplateSelector="{Binding ContentTemplateSelector, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
+    </Grid>
+</UserControl>

--- a/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml.cs
+++ b/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace BNKaraoke.DJ.Views.Overlays
+{
+    public partial class OverlayBand : UserControl
+    {
+        public OverlayBand()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -4,8 +4,12 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:vlc="clr-namespace:LibVLCSharp.WPF;assembly=LibVLCSharp.WPF"
+        xmlns:overlays="clr-namespace:BNKaraoke.DJ.Views.Overlays"
+        xmlns:viewModels="clr-namespace:BNKaraoke.DJ.ViewModels.Overlays"
         mc:Ignorable="d"
-        Title="BNKaraoke.com" WindowState="Maximized" WindowStyle="None"
+        Title="BNKaraoke.com"
+        WindowState="Maximized"
+        WindowStyle="None"
         WindowStartupLocation="Manual">
     <Window.Resources>
         <LinearGradientBrush x:Key="WindowBackground" StartPoint="0,0" EndPoint="0,1">
@@ -13,16 +17,58 @@
             <GradientStop Color="#3b82f6" Offset="1"/>
         </LinearGradientBrush>
     </Window.Resources>
-    <Grid Background="{StaticResource WindowBackground}">
-        <vlc:VideoView x:Name="VideoPlayer" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Margin="0" Background="#1e3a8a"/>
-        <Grid x:Name="TitleOverlay" VerticalAlignment="Center" HorizontalAlignment="Center" Panel.ZIndex="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
-            </Grid.RowDefinitions>
-            <Image Grid.Row="0" Source="pack://application:,,,/Assets/bnk-qr-code.png" Width="200" Height="200" Margin="0,0,0,20"/>
-            <TextBlock Grid.Row="1" Text="BNKaraoke.com" FontSize="70" FontWeight="Bold" Foreground="White"
-                       HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"/>
+    <Grid Background="{StaticResource WindowBackground}"
+          DataContext="{x:Static viewModels:OverlayViewModel.Instance}"
+          SnapsToDevicePixels="True">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="{Binding TopRowHeight}"/>
+            <RowDefinition Height="{Binding CenterRowHeight}"/>
+            <RowDefinition Height="{Binding BottomRowHeight}"/>
+        </Grid.RowDefinitions>
+
+        <overlays:OverlayBand Grid.Row="0"
+                              Visibility="{Binding TopBandVisibility}"
+                              Background="{Binding TopBandBrush}"/>
+
+        <Grid Grid.Row="1"
+              x:Name="VideoHost"
+              Background="Black"
+              ClipToBounds="True">
+            <vlc:VideoView x:Name="VideoPlayer"
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Stretch"
+                           Margin="0"
+                           Background="#000000"/>
+            <Grid x:Name="TitleOverlay"
+                  Background="{StaticResource WindowBackground}"
+                  Panel.ZIndex="1"
+                  HorizontalAlignment="Stretch"
+                  VerticalAlignment="Stretch">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <StackPanel Grid.Row="1"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center">
+                    <Image Source="pack://application:,,,/Assets/bnk-qr-code.png"
+                           Width="200"
+                           Height="200"
+                           Margin="0,0,0,20"/>
+                    <TextBlock Text="{Binding Brand}"
+                               FontSize="70"
+                               FontWeight="Bold"
+                               Foreground="White"
+                               HorizontalAlignment="Center"
+                               TextWrapping="Wrap"
+                               TextAlignment="Center"/>
+                </StackPanel>
+            </Grid>
         </Grid>
+
+        <overlays:OverlayBand Grid.Row="2"
+                              Visibility="{Binding BottomBandVisibility}"
+                              Background="{Binding BottomBandBrush}"/>
     </Grid>
 </Window>

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -400,8 +400,11 @@ namespace BNKaraoke.DJ.Views
 
         private void VideoPlayerWindow_SizeChanged(object? sender, SizeChangedEventArgs e)
         {
-            VideoPlayer.Width = e.NewSize.Width;
-            VideoPlayer.Height = e.NewSize.Height;
+            double hostWidth = VideoHost.ActualWidth;
+            double hostHeight = VideoHost.ActualHeight;
+
+            VideoPlayer.Width = hostWidth > 0 ? hostWidth : e.NewSize.Width;
+            VideoPlayer.Height = hostHeight > 0 ? hostHeight : e.NewSize.Height;
         }
 
         private void MediaPlayer_EndReached(object? sender, EventArgs e)
@@ -573,8 +576,8 @@ namespace BNKaraoke.DJ.Views
                 {
                     TitleOverlay.Visibility = Visibility.Collapsed;
                     VideoPlayer.Visibility = Visibility.Visible;
-                    VideoPlayer.Width = ActualWidth;
-                    VideoPlayer.Height = ActualHeight;
+                    VideoPlayer.Width = VideoHost.ActualWidth > 0 ? VideoHost.ActualWidth : ActualWidth;
+                    VideoPlayer.Height = VideoHost.ActualHeight > 0 ? VideoHost.ActualHeight : ActualHeight;
                     VideoPlayer.UpdateLayout();
                 }
 


### PR DESCRIPTION
## Summary
- reuse the existing placeholder overlay inside the video player window instead of introducing a standalone blue screen window
- restructure the video player layout so the top and bottom overlay bands wrap both video playback and the idle placeholder state

## Testing
- dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj *(fails: dotnet CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfc32476b88323905e5464613164d7