### PR TITLE
Add overlay template engine and blue state switching

### DIFF
--- a/BNKaraoke.DJ.Tests/BNKaraoke.DJ.Tests.csproj
+++ b/BNKaraoke.DJ.Tests/BNKaraoke.DJ.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BNKaraoke.DJ\BNKaraoke.DJ.csproj" />
+  </ItemGroup>
+</Project>

--- a/BNKaraoke.DJ.Tests/OverlayTemplateEngineTests.cs
+++ b/BNKaraoke.DJ.Tests/OverlayTemplateEngineTests.cs
@@ -1,0 +1,58 @@
+using System;
+using BNKaraoke.DJ.Services.Overlay;
+using Xunit;
+
+namespace BNKaraoke.DJ.Tests
+{
+    public class OverlayTemplateEngineTests
+    {
+        [Fact]
+        public void Render_ReplacesTokensWithValues()
+        {
+            var engine = new OverlayTemplateEngine();
+            var context = new OverlayTemplateContext
+            {
+                Brand = "BNK",
+                Requestor = "Alice",
+                Song = "Song",
+                Artist = "Artist",
+                UpNextRequestor = "Bob",
+                UpNextSong = "Tune",
+                UpNextArtist = "Singer",
+                EventName = "Party",
+                Venue = "Club",
+                Timestamp = new DateTimeOffset(2024, 1, 1, 20, 15, 0, TimeSpan.Zero)
+            };
+
+            var template = "{Brand} - {Requestor} - {Song} - {Artist} - {UpNextRequestor} - {UpNextSong} - {UpNextArtist} - {EventName} - {Venue} - {Time}";
+            var result = engine.Render(template, context);
+
+            Assert.Equal("BNK - Alice - Song - Artist - Bob - Tune - Singer - Party - Club - 8:15 PM", result);
+        }
+
+        [Fact]
+        public void Render_HandlesMissingValues()
+        {
+            var engine = new OverlayTemplateEngine();
+            var context = new OverlayTemplateContext();
+
+            var result = engine.Render("Play {Requestor}  {Song}", context);
+
+            Assert.Equal("Play", result);
+        }
+
+        [Fact]
+        public void Render_UsesTimestampForTimeToken()
+        {
+            var engine = new OverlayTemplateEngine();
+            var context = new OverlayTemplateContext
+            {
+                Timestamp = new DateTimeOffset(2024, 6, 1, 21, 30, 0, TimeSpan.Zero)
+            };
+
+            var result = engine.Render("It is {Time}", context);
+
+            Assert.Equal("It is 9:30 PM", result);
+        }
+    }
+}

--- a/BNKaraoke.DJ.Tests/OverlayViewModelTests.cs
+++ b/BNKaraoke.DJ.Tests/OverlayViewModelTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Reflection;
+using BNKaraoke.DJ.Models;
+using BNKaraoke.DJ.ViewModels.Overlays;
+using Xunit;
+
+namespace BNKaraoke.DJ.Tests
+{
+    public class OverlayViewModelTests
+    {
+        [Fact]
+        public void ActiveTemplatesSwitchWhenBlueStateChanges()
+        {
+            var viewModel = CreateViewModel();
+
+            viewModel.TopTemplatePlayback = "Playback {Requestor}";
+            viewModel.BottomTemplatePlayback = "Playback {Song}";
+            viewModel.TopTemplateBlue = "Blue {UpNextRequestor}";
+            viewModel.BottomTemplateBlue = "Blue {Brand}";
+            viewModel.BrandText = "BNK";
+
+            var nowPlaying = new QueueEntry
+            {
+                RequestorDisplayName = "Alice",
+                SongTitle = "Wonderwall",
+                SongArtist = "Oasis"
+            };
+            var upNext = new QueueEntry
+            {
+                RequestorDisplayName = "Bob"
+            };
+
+            viewModel.UpdateFromQueue(nowPlaying, upNext, null);
+
+            viewModel.IsBlueState = false;
+
+            Assert.Equal("Playback Alice", viewModel.TopBandText);
+            Assert.Equal("Playback Wonderwall", viewModel.BottomBandText);
+
+            viewModel.IsBlueState = true;
+
+            Assert.Equal("Blue Bob", viewModel.TopBandText);
+            Assert.Equal("Blue BNK", viewModel.BottomBandText);
+        }
+
+        private static OverlayViewModel CreateViewModel()
+        {
+            var type = typeof(OverlayViewModel);
+            var instance = (OverlayViewModel)Activator.CreateInstance(type, BindingFlags.Instance | BindingFlags.NonPublic, null, Array.Empty<object?>(), null)!;
+            var suppressField = type.GetField("_suppressSave", BindingFlags.Instance | BindingFlags.NonPublic);
+            suppressField?.SetValue(instance, true);
+            return instance;
+        }
+    }
+}

--- a/BNKaraoke.DJ/Models/OverlaySettings.cs
+++ b/BNKaraoke.DJ/Models/OverlaySettings.cs
@@ -13,12 +13,15 @@ namespace BNKaraoke.DJ.Models
         public string PrimaryColor { get; set; } = "#1e3a8a";
         public string SecondaryColor { get; set; } = "#3b82f6";
         public string Brand { get; set; } = "BNKaraoke.com";
+        public OverlayTemplates Templates { get; set; } = new OverlayTemplates();
 
         public void Clamp()
         {
             TopHeightPercent = ClampPercent(TopHeightPercent);
             BottomHeightPercent = ClampPercent(BottomHeightPercent);
             BackgroundOpacity = Math.Clamp(BackgroundOpacity, 0.0, 1.0);
+            Templates ??= new OverlayTemplates();
+            Templates.EnsureDefaults();
         }
 
         private static double ClampPercent(double value)

--- a/BNKaraoke.DJ/Models/OverlayTemplates.cs
+++ b/BNKaraoke.DJ/Models/OverlayTemplates.cs
@@ -1,0 +1,34 @@
+namespace BNKaraoke.DJ.Models
+{
+    public class OverlayTemplates
+    {
+        private const string DefaultPlaybackTop = "{Brand} • UP NEXT: {UpNextRequestor} – {UpNextSong} – {UpNextArtist}";
+        private const string DefaultPlaybackBottom = "{Brand} • NOW PLAYING: {Requestor} – {Song} – {Artist}";
+        private const string DefaultBlueTop = "{Brand} • UP NEXT: {UpNextRequestor} – {UpNextSong} – {UpNextArtist}";
+        private const string DefaultBlueBottom = "{Brand} • REQUEST A SONG AT {Brand}";
+
+        public string PlaybackTop { get; set; } = DefaultPlaybackTop;
+        public string PlaybackBottom { get; set; } = DefaultPlaybackBottom;
+        public string BlueTop { get; set; } = DefaultBlueTop;
+        public string BlueBottom { get; set; } = DefaultBlueBottom;
+
+        public OverlayTemplates Clone()
+        {
+            return new OverlayTemplates
+            {
+                PlaybackTop = PlaybackTop,
+                PlaybackBottom = PlaybackBottom,
+                BlueTop = BlueTop,
+                BlueBottom = BlueBottom
+            };
+        }
+
+        public void EnsureDefaults()
+        {
+            PlaybackTop = string.IsNullOrWhiteSpace(PlaybackTop) ? DefaultPlaybackTop : PlaybackTop;
+            PlaybackBottom = string.IsNullOrWhiteSpace(PlaybackBottom) ? DefaultPlaybackBottom : PlaybackBottom;
+            BlueTop = string.IsNullOrWhiteSpace(BlueTop) ? DefaultBlueTop : BlueTop;
+            BlueBottom = string.IsNullOrWhiteSpace(BlueBottom) ? DefaultBlueBottom : BlueBottom;
+        }
+    }
+}

--- a/BNKaraoke.DJ/Services/Overlay/OverlayTemplateEngine.cs
+++ b/BNKaraoke.DJ/Services/Overlay/OverlayTemplateEngine.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace BNKaraoke.DJ.Services.Overlay
+{
+    public class OverlayTemplateContext
+    {
+        public string Brand { get; set; } = string.Empty;
+        public string Requestor { get; set; } = string.Empty;
+        public string Song { get; set; } = string.Empty;
+        public string Artist { get; set; } = string.Empty;
+        public string UpNextRequestor { get; set; } = string.Empty;
+        public string UpNextSong { get; set; } = string.Empty;
+        public string UpNextArtist { get; set; } = string.Empty;
+        public string EventName { get; set; } = string.Empty;
+        public string Venue { get; set; } = string.Empty;
+        public DateTimeOffset? Timestamp { get; set; }
+        internal string GetValue(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return string.Empty;
+            }
+
+            return token.ToLowerInvariant() switch
+            {
+                "brand" => Brand ?? string.Empty,
+                "requestor" => Requestor ?? string.Empty,
+                "song" => Song ?? string.Empty,
+                "artist" => Artist ?? string.Empty,
+                "upnextrequestor" => UpNextRequestor ?? string.Empty,
+                "upnextsong" => UpNextSong ?? string.Empty,
+                "upnextartist" => UpNextArtist ?? string.Empty,
+                "eventname" => EventName ?? string.Empty,
+                "venue" => Venue ?? string.Empty,
+                "time" => FormatTime(Timestamp),
+                _ => string.Empty,
+            };
+        }
+
+        private static string FormatTime(DateTimeOffset? timestamp)
+        {
+            var value = timestamp ?? DateTimeOffset.Now;
+            return value.ToString("h:mm tt", CultureInfo.InvariantCulture);
+        }
+    }
+
+    public class OverlayTemplateEngine
+    {
+        private static readonly Regex TokenRegex = new(@"\{(?<token>[A-Za-z]+)\}", RegexOptions.Compiled);
+        private static readonly Regex MultiSpaceRegex = new(@"\s{2,}", RegexOptions.Compiled);
+
+        public string Render(string template, OverlayTemplateContext context)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (string.IsNullOrWhiteSpace(template))
+            {
+                return string.Empty;
+            }
+
+            var replaced = TokenRegex.Replace(template, match =>
+            {
+                var token = match.Groups["token"].Value;
+                return context.GetValue(token);
+            });
+
+            replaced = MultiSpaceRegex.Replace(replaced, " ");
+            return replaced.Trim();
+        }
+    }
+}

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Overlays.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Overlays.cs
@@ -1,0 +1,161 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using BNKaraoke.DJ.Models;
+using BNKaraoke.DJ.ViewModels.Overlays;
+
+namespace BNKaraoke.DJ.ViewModels
+{
+    public partial class DJScreenViewModel
+    {
+        private readonly HashSet<QueueEntry> _entriesWithHandlers = new();
+        private ObservableCollection<QueueEntry>? _trackedQueueEntries;
+
+        partial void OnPlayingQueueEntryChanged(QueueEntry? value)
+        {
+            UpdateOverlayState();
+        }
+
+        partial void OnCurrentEventChanged(EventDto? value)
+        {
+            UpdateOverlayState();
+        }
+
+        partial void OnQueueEntriesChanged(ObservableCollection<QueueEntry> value)
+        {
+            AttachQueueEntries(value);
+            UpdateOverlayState();
+        }
+
+        private void InitializeOverlayBindings()
+        {
+            AttachQueueEntries(QueueEntries);
+            UpdateOverlayState();
+        }
+
+        private void AttachQueueEntries(ObservableCollection<QueueEntry>? entries)
+        {
+            if (_trackedQueueEntries != null)
+            {
+                _trackedQueueEntries.CollectionChanged -= QueueEntries_CollectionChanged;
+                foreach (var entry in _trackedQueueEntries)
+                {
+                    if (_entriesWithHandlers.Remove(entry))
+                    {
+                        entry.PropertyChanged -= QueueEntry_PropertyChanged;
+                    }
+                }
+            }
+
+            _trackedQueueEntries = entries;
+
+            if (_trackedQueueEntries != null)
+            {
+                _trackedQueueEntries.CollectionChanged += QueueEntries_CollectionChanged;
+                foreach (var entry in _trackedQueueEntries)
+                {
+                    if (_entriesWithHandlers.Add(entry))
+                    {
+                        entry.PropertyChanged += QueueEntry_PropertyChanged;
+                    }
+                }
+            }
+        }
+
+        private void QueueEntries_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var entry in _entriesWithHandlers.ToList())
+                {
+                    entry.PropertyChanged -= QueueEntry_PropertyChanged;
+                }
+
+                _entriesWithHandlers.Clear();
+                if (_trackedQueueEntries != null)
+                {
+                    foreach (var entry in _trackedQueueEntries)
+                    {
+                        if (_entriesWithHandlers.Add(entry))
+                        {
+                            entry.PropertyChanged += QueueEntry_PropertyChanged;
+                        }
+                    }
+                }
+                UpdateOverlayState();
+                return;
+            }
+
+            if (e.OldItems != null)
+            {
+                foreach (QueueEntry entry in e.OldItems)
+                {
+                    if (_entriesWithHandlers.Remove(entry))
+                    {
+                        entry.PropertyChanged -= QueueEntry_PropertyChanged;
+                    }
+                }
+            }
+
+            if (e.NewItems != null)
+            {
+                foreach (QueueEntry entry in e.NewItems)
+                {
+                    if (_entriesWithHandlers.Add(entry))
+                    {
+                        entry.PropertyChanged += QueueEntry_PropertyChanged;
+                    }
+                }
+            }
+
+            UpdateOverlayState();
+        }
+
+        private void QueueEntry_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName is nameof(QueueEntry.IsUpNext)
+                or nameof(QueueEntry.IsCurrentlyPlaying)
+                or nameof(QueueEntry.RequestorDisplayName)
+                or nameof(QueueEntry.RequestorUserName)
+                or nameof(QueueEntry.SongTitle)
+                or nameof(QueueEntry.SongArtist)
+                or nameof(QueueEntry.IsActive)
+                or nameof(QueueEntry.IsOnHold)
+                or nameof(QueueEntry.Position))
+            {
+                UpdateOverlayState();
+            }
+        }
+
+        private void UpdateOverlayState()
+        {
+            var overlay = OverlayViewModel.Instance;
+            var playing = PlayingQueueEntry;
+            var upNext = DetermineUpNextEntry();
+            var currentEvent = CurrentEvent;
+            overlay.UpdateFromQueue(playing, upNext, currentEvent);
+        }
+
+        private QueueEntry? DetermineUpNextEntry()
+        {
+            var playingId = PlayingQueueEntry?.QueueId;
+
+            var upNext = QueueEntries
+                .Where(q => q.IsUpNext && (!playingId.HasValue || q.QueueId != playingId.Value))
+                .OrderBy(q => q.Position)
+                .FirstOrDefault();
+
+            if (upNext != null)
+            {
+                return upNext;
+            }
+
+            return QueueEntries
+                .Where(q => (!playingId.HasValue || q.QueueId != playingId.Value) && q.IsActive && !q.IsOnHold)
+                .OrderBy(q => q.Position)
+                .FirstOrDefault();
+        }
+    }
+}

--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.cs
@@ -95,6 +95,7 @@ namespace BNKaraoke.DJ.ViewModels
                 DecreaseBassBoostCommand = new RelayCommand(_ => BassBoost = Math.Max(0, BassBoost - 1));
                 UpdateAuthenticationStateInitial();
                 LoadLiveEventsAsync().GetAwaiter().GetResult();
+                InitializeOverlayBindings();
                 Log.Information("[DJSCREEN VM] Initialized UI state in constructor");
                 Log.Information("[DJSCREEN VM] ViewModel instance created: {InstanceId}", GetHashCode());
             }

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using BNKaraoke.DJ.Models;
 using BNKaraoke.DJ.Services;
+using BNKaraoke.DJ.ViewModels.Overlays;
 using LibVLCSharp.Shared;
 using Serilog;
 using System;
@@ -127,6 +128,7 @@ namespace BNKaraoke.DJ.Views
                 Owner = null;
                 WindowStartupLocation = WindowStartupLocation.Manual;
                 InitializeComponent();
+                OverlayViewModel.Instance.IsBlueState = true;
                 InitializeMediaPlayer();
                 SourceInitialized += VideoPlayerWindow_SourceInitialized;
                 Loaded += VideoPlayerWindow_Loaded;
@@ -575,6 +577,7 @@ namespace BNKaraoke.DJ.Views
                 if (!isDiagnostic)
                 {
                     TitleOverlay.Visibility = Visibility.Collapsed;
+                    OverlayViewModel.Instance.IsBlueState = false;
                     VideoPlayer.Visibility = Visibility.Visible;
                     VideoPlayer.Width = VideoHost.ActualWidth > 0 ? VideoHost.ActualWidth : ActualWidth;
                     VideoPlayer.Height = VideoHost.ActualHeight > 0 ? VideoHost.ActualHeight : ActualHeight;
@@ -784,6 +787,7 @@ namespace BNKaraoke.DJ.Views
                 {
                     MediaPlayer.Pause();
                     TitleOverlay.Visibility = Visibility.Visible;
+                    OverlayViewModel.Instance.IsBlueState = true;
                     Visibility = Visibility.Visible;
                     Show();
                     Activate();
@@ -816,12 +820,14 @@ namespace BNKaraoke.DJ.Views
                     DisposeCurrentMedia();
                     VideoPlayer.Visibility = Visibility.Collapsed;
                     TitleOverlay.Visibility = Visibility.Visible;
+                    OverlayViewModel.Instance.IsBlueState = true;
                     Log.Information("[VIDEO PLAYER] Video stopped, VLC state: IsPlaying={IsPlaying}, State={State}",
                         MediaPlayer.IsPlaying, MediaPlayer.State);
                 }
                 else
                 {
                     TitleOverlay.Visibility = Visibility.Visible;
+                    OverlayViewModel.Instance.IsBlueState = true;
                     Log.Information("[VIDEO PLAYER] No video playing or paused to stop");
                 }
                 _currentVideoPath = null;

--- a/BNKaraoke.sln
+++ b/BNKaraoke.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BNKaraoke.Api.Tests", "BNKa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BNKaraoke.DJ", "BNKaraoke.DJ\BNKaraoke.DJ.csproj", "{5DB510AB-E880-20F5-C056-F45697DCADBF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BNKaraoke.DJ.Tests", "BNKaraoke.DJ.Tests\BNKaraoke.DJ.Tests.csproj", "{E6DE34A6-8E76-4001-97E8-A36EF1030F17}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,10 +60,22 @@ Global
 		{FB1470E1-8095-480E-8A6B-982716F50348}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB1470E1-8095-480E-8A6B-982716F50348}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FB1470E1-8095-480E-8A6B-982716F50348}.Release|x64.ActiveCfg = Release|Any CPU
-		{FB1470E1-8095-480E-8A6B-982716F50348}.Release|x64.Build.0 = Release|Any CPU
-		{FB1470E1-8095-480E-8A6B-982716F50348}.Release|x86.ActiveCfg = Release|Any CPU
-		{FB1470E1-8095-480E-8A6B-982716F50348}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {FB1470E1-8095-480E-8A6B-982716F50348}.Release|x64.Build.0 = Release|Any CPU
+                {FB1470E1-8095-480E-8A6B-982716F50348}.Release|x86.ActiveCfg = Release|Any CPU
+                {FB1470E1-8095-480E-8A6B-982716F50348}.Release|x86.Build.0 = Release|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Debug|x64.Build.0 = Debug|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Debug|x86.Build.0 = Debug|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Release|Any CPU.Build.0 = Release|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Release|x64.ActiveCfg = Release|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Release|x64.Build.0 = Release|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Release|x86.ActiveCfg = Release|Any CPU
+                {E6DE34A6-8E76-4001-97E8-A36EF1030F17}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add default overlay templates and tokenized rendering with a new overlay template engine
- update the overlay view model to manage playback and blue-state templates, brand text, and queue-driven content
- hook the DJ screen and video player to refresh overlay data and blue-state visibility, and add unit tests for the new behavior

## Testing
- dotnet test BNKaraoke.sln *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd57e18148323a7c335b226f81d29