### PR TITLE
Fix overlay band padding XAML

### DIFF
--- a/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml
+++ b/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml
@@ -9,17 +9,16 @@
              Focusable="False"
              IsTabStop="False"
              UseLayoutRounding="True"
-             SnapsToDevicePixels="True"
-             Padding="32,24">
-    <Grid Background="{Binding Background, RelativeSource={RelativeSource AncestorType=UserControl}}"
-          Padding="{Binding Padding, RelativeSource={RelativeSource AncestorType=UserControl}}"
-          HorizontalAlignment="Stretch"
-          VerticalAlignment="Stretch"
-          SnapsToDevicePixels="True">
+            SnapsToDevicePixels="True">
+    <Border Background="{Binding Background, RelativeSource={RelativeSource AncestorType=UserControl}}"
+            Padding="{Binding ContentPadding, RelativeSource={RelativeSource AncestorType=UserControl}}"
+            HorizontalAlignment="Stretch"
+            VerticalAlignment="Stretch"
+            SnapsToDevicePixels="True">
         <ContentPresenter HorizontalAlignment="Center"
                           VerticalAlignment="Center"
                           Content="{Binding Content, RelativeSource={RelativeSource AncestorType=UserControl}}"
                           ContentTemplate="{Binding ContentTemplate, RelativeSource={RelativeSource AncestorType=UserControl}}"
                           ContentTemplateSelector="{Binding ContentTemplateSelector, RelativeSource={RelativeSource AncestorType=UserControl}}"/>
-    </Grid>
+    </Border>
 </UserControl>

--- a/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml.cs
+++ b/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml.cs
@@ -1,12 +1,25 @@
+using System.Windows;
 using System.Windows.Controls;
 
 namespace BNKaraoke.DJ.Views.Overlays
 {
     public partial class OverlayBand : UserControl
     {
+        public static readonly DependencyProperty ContentPaddingProperty = DependencyProperty.Register(
+            nameof(ContentPadding),
+            typeof(Thickness),
+            typeof(OverlayBand),
+            new PropertyMetadata(new Thickness(32, 24, 32, 24)));
+
         public OverlayBand()
         {
             InitializeComponent();
+        }
+
+        public Thickness ContentPadding
+        {
+            get => (Thickness)GetValue(ContentPaddingProperty);
+            set => SetValue(ContentPaddingProperty, value);
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the inner Grid in `OverlayBand` with a Border so padding can be applied without relying on unsupported properties
- expose a `ContentPadding` dependency property and bind the Border padding to it for customization while keeping the previous default

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfdb38272c8323892715ae781c18f9