### PR TITLE
Fix overlay color parsing build error

### DIFF
--- a/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
@@ -545,11 +545,10 @@ namespace BNKaraoke.DJ.ViewModels.Overlays
 
             try
             {
-                var converter = new ColorConverter();
-                var converted = converter.ConvertFromString(color) as Color?;
-                if (converted.HasValue)
+                var converted = ColorConverter.ConvertFromString(color);
+                if (converted is Color colorValue)
                 {
-                    return converted.Value;
+                    return colorValue;
                 }
             }
             catch


### PR DESCRIPTION
## Summary
- fix the overlay color parsing to use the static `ColorConverter.ConvertFromString` API and avoid the build error

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfdc82916083239110d6f195cd0bcc