### PR TITLE
Fix crossfade marquee element parenting error

### DIFF
--- a/BNKaraoke.DJ/Controls/MarqueePresenter.cs
+++ b/BNKaraoke.DJ/Controls/MarqueePresenter.cs
@@ -299,11 +299,12 @@ namespace BNKaraoke.DJ.Controls
                 _currentLayer.BeginAnimation(UIElement.OpacityProperty, null);
                 _nextLayer.BeginAnimation(UIElement.OpacityProperty, null);
 
+                _nextLayer.Children.Clear();
+
                 _currentLayer.Children.Clear();
                 _currentLayer.Children.Add(newState.Root);
                 _currentLayer.Opacity = 1.0;
 
-                _nextLayer.Children.Clear();
                 _nextLayer.Opacity = 0.0;
 
                 if (previousState != null && previousState.IsMarquee)


### PR DESCRIPTION
## Summary
- clear the crossfade staging layer before reparenting the marquee content to avoid logical child exceptions during marquee updates

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfe26052bc8323a0df2d3bac75c89d