### PR TITLE
Wire overlays to playback resolver events

### DIFF
--- a/BNKaraoke.DJ.Tests/NowNextResolverTests.cs
+++ b/BNKaraoke.DJ.Tests/NowNextResolverTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using BNKaraoke.DJ.Models;
+using BNKaraoke.DJ.Services.Playback;
+using Xunit;
+
+namespace BNKaraoke.DJ.Tests
+{
+    public class NowNextResolverTests
+    {
+        [Fact]
+        public void ResolveNowReturnsPlayheadMatchFromQueue()
+        {
+            var queue = new List<QueueEntry>
+            {
+                CreateEntry(1, position: 1),
+                CreateEntry(2, position: 2)
+            };
+
+            var playhead = new QueueEntry { QueueId = 2 };
+            var resolver = new NowNextResolver(queue, playhead);
+
+            var result = resolver.ResolveNow();
+
+            Assert.NotNull(result);
+            Assert.Equal(2, result!.QueueId);
+        }
+
+        [Fact]
+        public void ResolveUpNextSkipsMatureInDeferMode()
+        {
+            var queue = new List<QueueEntry>
+            {
+                CreateEntry(1, position: 1),
+                CreateEntry(2, position: 2, isMature: true),
+                CreateEntry(3, position: 3)
+            };
+
+            var resolver = new NowNextResolver(queue, queue[0]);
+
+            var next = resolver.ResolveUpNext(ReorderMode.DeferMature);
+
+            Assert.NotNull(next);
+            Assert.Equal(3, next!.QueueId);
+        }
+
+        [Fact]
+        public void ResolveUpNextReturnsFirstPlayableWhenNowMissing()
+        {
+            var queue = new List<QueueEntry>
+            {
+                CreateEntry(10, position: 10, isActive: false),
+                CreateEntry(11, position: 11, isOnHold: true),
+                CreateEntry(12, position: 12)
+            };
+
+            var resolver = new NowNextResolver(queue, null);
+
+            var next = resolver.ResolveUpNext(ReorderMode.AllowMature);
+
+            Assert.NotNull(next);
+            Assert.Equal(12, next!.QueueId);
+        }
+
+        [Fact]
+        public void ResolveUpNextRespectsOrderingByPosition()
+        {
+            var queue = new List<QueueEntry>
+            {
+                CreateEntry(5, position: 20),
+                CreateEntry(6, position: 5),
+                CreateEntry(7, position: 15)
+            };
+
+            var resolver = new NowNextResolver(queue, queue[1]);
+
+            var next = resolver.ResolveUpNext(ReorderMode.AllowMature);
+
+            Assert.NotNull(next);
+            Assert.Equal(7, next!.QueueId);
+        }
+
+        private static QueueEntry CreateEntry(int queueId, int position, bool isMature = false, bool isActive = true, bool isOnHold = false)
+        {
+            return new QueueEntry
+            {
+                QueueId = queueId,
+                Position = position,
+                IsMature = isMature,
+                IsActive = isActive,
+                IsOnHold = isOnHold
+            };
+        }
+    }
+}

--- a/BNKaraoke.DJ.Tests/OverlayViewModelTests.cs
+++ b/BNKaraoke.DJ.Tests/OverlayViewModelTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using BNKaraoke.DJ.Models;
 using BNKaraoke.DJ.ViewModels.Overlays;
@@ -30,7 +31,8 @@ namespace BNKaraoke.DJ.Tests
                 RequestorDisplayName = "Bob"
             };
 
-            viewModel.UpdateFromQueue(nowPlaying, upNext, null);
+            var queue = new List<QueueEntry> { nowPlaying, upNext };
+            viewModel.UpdatePlaybackState(queue, nowPlaying, null, ReorderMode.AllowMature);
 
             viewModel.IsBlueState = false;
 

--- a/BNKaraoke.DJ/Services/IUserSessionService.cs
+++ b/BNKaraoke.DJ/Services/IUserSessionService.cs
@@ -12,7 +12,8 @@ namespace BNKaraoke.DJ.Services
         string? UserName { get; }
         List<string>? Roles { get; }
         ReorderMode? PreferredReorderMode { get; }
-        event EventHandler SessionChanged;
+        event EventHandler? SessionChanged;
+        event EventHandler<ReorderMode>? PreferredReorderModeChanged;
         void SetSession(LoginResult loginResult, string userName);
         void SetPreferredReorderMode(ReorderMode mode);
         void ClearSession();

--- a/BNKaraoke.DJ/Services/Playback/NowNextResolver.cs
+++ b/BNKaraoke.DJ/Services/Playback/NowNextResolver.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BNKaraoke.DJ.Models;
+
+namespace BNKaraoke.DJ.Services.Playback
+{
+    public class NowNextResolver
+    {
+        private readonly IReadOnlyList<QueueEntry> _queue;
+        private readonly QueueEntry? _playhead;
+
+        public NowNextResolver(IReadOnlyList<QueueEntry>? queue, QueueEntry? playhead)
+        {
+            _queue = queue ?? Array.Empty<QueueEntry>();
+            _playhead = playhead;
+        }
+
+        public QueueEntry? ResolveNow()
+        {
+            if (_playhead == null)
+            {
+                return null;
+            }
+
+            var matching = _queue.FirstOrDefault(entry => entry.QueueId == _playhead.QueueId);
+            return matching ?? _playhead;
+        }
+
+        public QueueEntry? ResolveUpNext(ReorderMode matureMode)
+        {
+            var ordered = _queue
+                .Where(entry => entry.IsActive && !entry.IsOnHold)
+                .OrderBy(entry => entry.Position)
+                .ToList();
+
+            if (ordered.Count == 0)
+            {
+                return null;
+            }
+
+            var now = ResolveNow();
+            var startIndex = now != null
+                ? ordered.FindIndex(entry => entry.QueueId == now.QueueId)
+                : -1;
+
+            for (var index = startIndex + 1; index < ordered.Count; index++)
+            {
+                var candidate = ordered[index];
+                if (matureMode == ReorderMode.DeferMature && candidate.IsMature)
+                {
+                    continue;
+                }
+
+                return candidate;
+            }
+
+            if (now == null)
+            {
+                foreach (var candidate in ordered)
+                {
+                    if (matureMode == ReorderMode.DeferMature && candidate.IsMature)
+                    {
+                        continue;
+                    }
+
+                    return candidate;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/BNKaraoke.DJ/Services/UserSessionService.cs
+++ b/BNKaraoke.DJ/Services/UserSessionService.cs
@@ -11,6 +11,7 @@ namespace BNKaraoke.DJ.Services
         public static UserSessionService Instance => _instance;
 
         public event EventHandler? SessionChanged;
+        public event EventHandler<ReorderMode>? PreferredReorderModeChanged;
 
         public bool IsAuthenticated { get; private set; }
         public string? Token { get; private set; }
@@ -67,7 +68,13 @@ namespace BNKaraoke.DJ.Services
 
         public void SetPreferredReorderMode(ReorderMode mode)
         {
+            if (PreferredReorderMode == mode)
+            {
+                return;
+            }
+
             PreferredReorderMode = mode;
+            PreferredReorderModeChanged?.Invoke(this, mode);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a playback NowNextResolver to calculate active and next queue entries with mature policy handling
- update OverlayViewModel to cache queue snapshots, listen for mature-mode changes, and recompute band text via the resolver
- feed overlay updates from DJScreenViewModel and cover the resolver with new unit tests

## Testing
- `dotnet test BNKaraoke.sln` *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfebc9203083238e41b6f8eb7f9220