### PR TITLE
Improve marquee performance and display resilience

### DIFF
--- a/BNKaraoke.DJ/Services/SettingsService.cs
+++ b/BNKaraoke.DJ/Services/SettingsService.cs
@@ -16,6 +16,7 @@ namespace BNKaraoke.DJ.Services
         private readonly string _settingsPath;
         public DjSettings Settings { get; private set; }
         public event EventHandler<string>? AudioDeviceChanged;
+        public event EventHandler<string>? VideoDeviceChanged;
 
         private SettingsService()
         {
@@ -128,12 +129,18 @@ namespace BNKaraoke.DJ.Services
                 var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
                 File.WriteAllText(_settingsPath, json);
                 var previousAudioDevice = Settings?.PreferredAudioDevice;
+                var previousVideoDevice = Settings?.KaraokeVideoDevice;
                 Settings = settings;
                 Log.Information("[SETTINGS SERVICE] Saved settings to {Path}, ApiUrl={ApiUrl}", _settingsPath, settings.ApiUrl);
                 if (!string.Equals(previousAudioDevice, settings.PreferredAudioDevice, StringComparison.OrdinalIgnoreCase))
                 {
                     AudioDeviceChanged?.Invoke(this, settings.PreferredAudioDevice);
                     Log.Information("[SETTINGS SERVICE] Notified audio device change: {DeviceId}", settings.PreferredAudioDevice);
+                }
+                if (!string.Equals(previousVideoDevice, settings.KaraokeVideoDevice, StringComparison.OrdinalIgnoreCase))
+                {
+                    VideoDeviceChanged?.Invoke(this, settings.KaraokeVideoDevice);
+                    Log.Information("[SETTINGS SERVICE] Notified video device change: {DeviceId}", settings.KaraokeVideoDevice);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- replace per-frame marquee updates with storyboard-driven animations, adaptive quality controls, and telemetry logging
- capture render timing to reduce drop shadow blur, pause/resume marquee during spikes, and log loop metrics for diagnostics
- surface karaoke display changes via a new video-device event and handle display reconfiguration in the video player window

## Testing
- dotnet build BNKaraoke.sln *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dff7e717d88323a6897f5221848099