### PR TITLE
Add custom StackPanel with spacing support

### DIFF
--- a/BNKaraoke.DJ/Controls/SpacingStackPanel.cs
+++ b/BNKaraoke.DJ/Controls/SpacingStackPanel.cs
@@ -1,0 +1,109 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace BNKaraoke.DJ.Controls;
+
+/// <summary>
+/// StackPanel that offers a <see cref="Spacing"/> property similar to WinUI's implementation.
+/// The control preserves any margins already set on the child elements and simply
+/// adds the requested spacing in the appropriate direction.
+/// </summary>
+public class SpacingStackPanel : StackPanel
+{
+    public static readonly DependencyProperty SpacingProperty = DependencyProperty.Register(
+        nameof(Spacing),
+        typeof(double),
+        typeof(SpacingStackPanel),
+        new FrameworkPropertyMetadata(0d, FrameworkPropertyMetadataOptions.AffectsMeasure, OnSpacingChanged));
+
+    private static readonly DependencyProperty OriginalMarginProperty = DependencyProperty.RegisterAttached(
+        "OriginalMargin",
+        typeof(Thickness),
+        typeof(SpacingStackPanel),
+        new FrameworkPropertyMetadata(default(Thickness)));
+
+    public double Spacing
+    {
+        get => (double)GetValue(SpacingProperty);
+        set => SetValue(SpacingProperty, value);
+    }
+
+    protected override void OnVisualChildrenChanged(DependencyObject? visualAdded, DependencyObject? visualRemoved)
+    {
+        if (visualRemoved is FrameworkElement removed)
+        {
+            removed.ClearValue(OriginalMarginProperty);
+        }
+
+        if (visualAdded is FrameworkElement added && added.ReadLocalValue(OriginalMarginProperty) == DependencyProperty.UnsetValue)
+        {
+            added.SetValue(OriginalMarginProperty, added.Margin);
+        }
+
+        base.OnVisualChildrenChanged(visualAdded, visualRemoved);
+
+        UpdateChildMargins();
+    }
+
+    protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        if (e.Property == OrientationProperty)
+        {
+            UpdateChildMargins();
+        }
+    }
+
+    private static void OnSpacingChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is SpacingStackPanel panel)
+        {
+            panel.UpdateChildMargins();
+        }
+    }
+
+    private void UpdateChildMargins()
+    {
+        var spacing = Spacing;
+        var childrenCount = InternalChildren.Count;
+
+        for (var index = 0; index < childrenCount; index++)
+        {
+            if (InternalChildren[index] is not FrameworkElement child)
+            {
+                continue;
+            }
+
+            if (child.ReadLocalValue(OriginalMarginProperty) == DependencyProperty.UnsetValue)
+            {
+                child.SetValue(OriginalMarginProperty, child.Margin);
+            }
+
+            var baseMargin = (Thickness)child.GetValue(OriginalMarginProperty);
+            Thickness newMargin;
+
+            if (Orientation == Orientation.Horizontal)
+            {
+                newMargin = new Thickness(
+                    baseMargin.Left + (index == 0 ? 0 : spacing),
+                    baseMargin.Top,
+                    baseMargin.Right,
+                    baseMargin.Bottom);
+            }
+            else
+            {
+                newMargin = new Thickness(
+                    baseMargin.Left,
+                    baseMargin.Top + (index == 0 ? 0 : spacing),
+                    baseMargin.Right,
+                    baseMargin.Bottom);
+            }
+
+            if (child.Margin != newMargin)
+            {
+                child.Margin = newMargin;
+            }
+        }
+    }
+}

--- a/BNKaraoke.DJ/Views/Settings/OverlaySettingsView.xaml
+++ b/BNKaraoke.DJ/Views/Settings/OverlaySettingsView.xaml
@@ -24,10 +24,10 @@
         <ScrollViewer Grid.Column="0"
                       VerticalScrollBarVisibility="Auto"
                       Margin="0,0,15,0">
-            <StackPanel Orientation="Vertical" Spacing="12">
+            <controls:SpacingStackPanel Orientation="Vertical" Spacing="12">
                 <GroupBox Header="Bands" Foreground="White">
-                    <StackPanel Margin="10" Spacing="10">
-                        <StackPanel Orientation="Horizontal" Spacing="10">
+                    <controls:SpacingStackPanel Margin="10" Spacing="10">
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10">
                             <ToggleButton Width="140"
                                           Padding="10,5"
                                           IsChecked="{Binding Overlay.IsTopEnabled, Mode=TwoWay}"
@@ -52,11 +52,11 @@
                                     <Run Text="{Binding Overlay.IsBottomEnabled, Converter={StaticResource BooleanToStringConverter}, ConverterParameter='Off;On'}" />
                                 </TextBlock>
                             </ToggleButton>
-                        </StackPanel>
+                        </controls:SpacingStackPanel>
 
                         <StackPanel>
                             <TextBlock Text="Top height" Foreground="White" />
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                            <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
                                 <Slider Width="240"
                                         Minimum="0"
                                         Maximum="0.4"
@@ -64,12 +64,12 @@
                                         IsSnapToTickEnabled="True"
                                         Value="{Binding Overlay.TopHeightPercent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Overlay.TopHeightPercent, StringFormat={}{0:P0}}" Foreground="White" Width="60" />
-                            </StackPanel>
+                            </controls:SpacingStackPanel>
                         </StackPanel>
 
                         <StackPanel>
                             <TextBlock Text="Bottom height" Foreground="White" />
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                            <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
                                 <Slider Width="240"
                                         Minimum="0"
                                         Maximum="0.4"
@@ -77,21 +77,21 @@
                                         IsSnapToTickEnabled="True"
                                         Value="{Binding Overlay.BottomHeightPercent, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                                 <TextBlock Text="{Binding Overlay.BottomHeightPercent, StringFormat={}{0:P0}}" Foreground="White" Width="60" />
-                            </StackPanel>
+                            </controls:SpacingStackPanel>
                         </StackPanel>
-                    </StackPanel>
+                    </controls:SpacingStackPanel>
                 </GroupBox>
 
                 <GroupBox Header="Branding" Foreground="White">
-                    <StackPanel Margin="10" Spacing="8">
+                    <controls:SpacingStackPanel Margin="10" Spacing="8">
                         <TextBlock Text="Brand text" Foreground="White" />
                         <TextBox Text="{Binding Overlay.BrandText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    </StackPanel>
+                    </controls:SpacingStackPanel>
                 </GroupBox>
 
                 <GroupBox Header="Background" Foreground="White">
-                    <StackPanel Margin="10" Spacing="10">
-                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                    <controls:SpacingStackPanel Margin="10" Spacing="10">
+                        <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
                             <TextBlock Text="Opacity" Foreground="White" Width="80" />
                             <Slider Width="240"
                                     Minimum="0"
@@ -100,35 +100,35 @@
                                     IsSnapToTickEnabled="True"
                                     Value="{Binding Overlay.BackgroundOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock Text="{Binding Overlay.BackgroundOpacity, StringFormat=F2}" Foreground="White" Width="60" />
-                        </StackPanel>
+                        </controls:SpacingStackPanel>
                         <CheckBox Content="Use gradient"
                                   IsChecked="{Binding Overlay.UseGradient, Mode=TwoWay}"
                                   Foreground="White" />
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Primary" Foreground="White" Width="80" />
                             <TextBox Width="120" Text="{Binding Overlay.PrimaryColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <Border Width="32" Height="32" CornerRadius="4" BorderBrush="White" BorderThickness="1"
                                     Background="{Binding Overlay.PrimaryColor}" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        </controls:SpacingStackPanel>
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Secondary" Foreground="White" Width="80" />
                             <TextBox Width="120" Text="{Binding Overlay.SecondaryColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <Border Width="32" Height="32" CornerRadius="4" BorderBrush="White" BorderThickness="1"
                                     Background="{Binding Overlay.SecondaryColor}" />
-                        </StackPanel>
-                    </StackPanel>
+                        </controls:SpacingStackPanel>
+                    </controls:SpacingStackPanel>
                 </GroupBox>
 
                 <GroupBox Header="Typography" Foreground="White">
-                    <StackPanel Margin="10" Spacing="10">
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <controls:SpacingStackPanel Margin="10" Spacing="10">
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Font" Foreground="White" Width="80" />
                             <ComboBox Width="220"
                                       ItemsSource="{Binding AvailableFontFamilies}"
                                       SelectedItem="{Binding SelectedFontFamily, Mode=TwoWay}"
                                       DisplayMemberPath="Source" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        </controls:SpacingStackPanel>
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Size" Foreground="White" Width="80" />
                             <Slider Width="220"
                                     Minimum="16"
@@ -137,8 +137,8 @@
                                     IsSnapToTickEnabled="True"
                                     Value="{Binding Overlay.FontSize, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock Text="{Binding Overlay.FontSize, StringFormat=F0}" Foreground="White" Width="60" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        </controls:SpacingStackPanel>
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Weight" Foreground="White" Width="80" />
                             <ComboBox Width="220"
                                       ItemsSource="{Binding AvailableFontWeights}"
@@ -149,26 +149,26 @@
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        </controls:SpacingStackPanel>
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Text Color" Foreground="White" Width="80" />
                             <TextBox Width="120" Text="{Binding Overlay.FontColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <Border Width="32" Height="32" CornerRadius="4" BorderBrush="White" BorderThickness="1" Background="{Binding Overlay.FontBrush}" />
-                        </StackPanel>
+                        </controls:SpacingStackPanel>
                         <CheckBox Content="Enable stroke"
                                   IsChecked="{Binding Overlay.IsStrokeEnabled, Mode=TwoWay}"
                                   Foreground="White" />
                         <CheckBox Content="Enable shadow"
                                   IsChecked="{Binding Overlay.IsShadowEnabled, Mode=TwoWay}"
                                   Foreground="White" />
-                    </StackPanel>
+                    </controls:SpacingStackPanel>
                 </GroupBox>
 
                 <GroupBox Header="Templates" Foreground="White">
-                    <StackPanel Margin="10" Spacing="10">
+                    <controls:SpacingStackPanel Margin="10" Spacing="10">
                         <TabControl>
                             <TabItem Header="Playback">
-                                <StackPanel Margin="10" Spacing="8">
+                                <controls:SpacingStackPanel Margin="10" Spacing="8">
                                     <TextBlock Text="Top band" Foreground="White" />
                                     <TextBox Text="{Binding Overlay.TopTemplatePlayback, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                              AcceptsReturn="True"
@@ -179,10 +179,10 @@
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"
                                              Height="60" />
-                                </StackPanel>
+                                </controls:SpacingStackPanel>
                             </TabItem>
                             <TabItem Header="Blue Screen">
-                                <StackPanel Margin="10" Spacing="8">
+                                <controls:SpacingStackPanel Margin="10" Spacing="8">
                                     <TextBlock Text="Top band" Foreground="White" />
                                     <TextBox Text="{Binding Overlay.TopTemplateBlue, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                              AcceptsReturn="True"
@@ -193,7 +193,7 @@
                                              AcceptsReturn="True"
                                              TextWrapping="Wrap"
                                              Height="60" />
-                                </StackPanel>
+                                </controls:SpacingStackPanel>
                             </TabItem>
                         </TabControl>
                         <Button Content="Reset to Defaults"
@@ -216,15 +216,15 @@
                                 </ItemsControl.ItemTemplate>
                             </ItemsControl>
                         </GroupBox>
-                    </StackPanel>
+                    </controls:SpacingStackPanel>
                 </GroupBox>
 
                 <GroupBox Header="Marquee" Foreground="White">
-                    <StackPanel Margin="10" Spacing="10">
+                    <controls:SpacingStackPanel Margin="10" Spacing="10">
                         <CheckBox Content="Enable marquee"
                                   IsChecked="{Binding Overlay.MarqueeEnabled, Mode=TwoWay}"
                                   Foreground="White" />
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Speed (px/s)" Foreground="White" Width="120" />
                             <Slider Width="220"
                                     Minimum="10"
@@ -233,8 +233,8 @@
                                     IsSnapToTickEnabled="True"
                                     Value="{Binding Overlay.MarqueeSpeedPxPerSecond, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock Text="{Binding Overlay.MarqueeSpeedPxPerSecond, StringFormat=F0}" Foreground="White" Width="60" />
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        </controls:SpacingStackPanel>
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <TextBlock Text="Spacer (px)" Foreground="White" Width="120" />
                             <Slider Width="220"
                                     Minimum="20"
@@ -243,10 +243,10 @@
                                     IsSnapToTickEnabled="True"
                                     Value="{Binding Overlay.MarqueeSpacerWidthPx, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock Text="{Binding Overlay.MarqueeSpacerWidthPx, StringFormat=F0}" Foreground="White" Width="60" />
-                        </StackPanel>
-                    </StackPanel>
+                        </controls:SpacingStackPanel>
+                    </controls:SpacingStackPanel>
                 </GroupBox>
-            </StackPanel>
+            </controls:SpacingStackPanel>
         </ScrollViewer>
 
         <GroupBox Grid.Column="1" Header="Preview" Foreground="White">
@@ -256,12 +256,12 @@
                     <RowDefinition Height="*" />
                 </Grid.RowDefinitions>
 
-                <StackPanel Orientation="Horizontal" Spacing="10">
+                <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10">
                     <TextBlock Text="{Binding PreviewModeLabel}" Foreground="White" VerticalAlignment="Center" />
                     <CheckBox Content="Blue screen"
                               IsChecked="{Binding IsBluePreview, Mode=TwoWay}"
                               Foreground="White" />
-                </StackPanel>
+                </controls:SpacingStackPanel>
 
                 <Grid Grid.Row="1" Margin="0,10,0,0">
                     <Grid.RowDefinitions>

--- a/BNKaraoke.DJ/Views/SettingsWindow.xaml
+++ b/BNKaraoke.DJ/Views/SettingsWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:BNKaraoke.DJ.Converters"
+        xmlns:controls="clr-namespace:BNKaraoke.DJ.Controls"
         xmlns:settingsViews="clr-namespace:BNKaraoke.DJ.Views.Settings"
         Title="Settings" Height="720" Width="720" WindowStartupLocation="CenterScreen" Background="#1E3A5F">
     <Window.Resources>
@@ -16,17 +17,17 @@
         <TabControl Grid.Row="0" Margin="0,0,0,12">
             <TabItem Header="General">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="12" Spacing="12">
+                    <controls:SpacingStackPanel Margin="12" Spacing="12">
                         <GroupBox Header="Application Settings" Foreground="White">
-                            <StackPanel Margin="10" Spacing="8">
+                            <controls:SpacingStackPanel Margin="10" Spacing="8">
                                 <TextBlock Text="API URL" Foreground="White"/>
                                 <ComboBox ItemsSource="{Binding AvailableApiUrls}" SelectedItem="{Binding ApiUrl}" Width="300" HorizontalAlignment="Left"/>
                                 <TextBlock Text="New API URL" Foreground="White"/>
-                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                <controls:SpacingStackPanel Orientation="Horizontal" Spacing="6">
                                     <TextBox Text="{Binding NewApiUrl, UpdateSourceTrigger=PropertyChanged}" Width="220"/>
                                     <Button Content="Add" Width="60" Command="{Binding AddApiUrlCommand}"/>
                                     <Button Content="Remove" Width="80" Command="{Binding RemoveApiUrlCommand}"/>
-                                </StackPanel>
+                                </controls:SpacingStackPanel>
                                 <CheckBox Content="Enable SignalR Sync" IsChecked="{Binding EnableSignalRSync}" Foreground="White"/>
                                 <TextBlock Text="SignalR Hub URL" Foreground="White"/>
                                 <TextBox Text="{Binding SignalRHubUrl}" Width="300" HorizontalAlignment="Left"/>
@@ -35,44 +36,44 @@
                                 <CheckBox Content="Show Debug Console" IsChecked="{Binding ShowDebugConsole}" Foreground="White"/>
                                 <CheckBox Content="Enable Verbose Logging" IsChecked="{Binding EnableVerboseLogging}" Foreground="White"/>
                                 <TextBlock Text="Log File Path" Foreground="White"/>
-                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                <controls:SpacingStackPanel Orientation="Horizontal" Spacing="6">
                                     <TextBox Text="{Binding LogFilePath}" Width="320"/>
                                     <Button Content="Browse" Width="80" Command="{Binding BrowseLogFilePathCommand}"/>
-                                </StackPanel>
-                            </StackPanel>
+                                </controls:SpacingStackPanel>
+                            </controls:SpacingStackPanel>
                         </GroupBox>
-                    </StackPanel>
+                    </controls:SpacingStackPanel>
                 </ScrollViewer>
             </TabItem>
 
             <TabItem Header="Devices">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="12" Spacing="12">
+                    <controls:SpacingStackPanel Margin="12" Spacing="12">
                         <GroupBox Header="Audio and Video" Foreground="White">
-                            <StackPanel Margin="10" Spacing="8">
+                            <controls:SpacingStackPanel Margin="10" Spacing="8">
                                 <TextBlock Text="Preferred Audio Device" Foreground="White"/>
                                 <ComboBox ItemsSource="{Binding AvailableAudioDevices}" SelectedItem="{Binding PreferredAudioDevice}" DisplayMemberPath="DisplayName" Width="320" HorizontalAlignment="Left"/>
                                 <TextBlock Text="Karaoke Video Device" Foreground="White"/>
                                 <ComboBox ItemsSource="{Binding AvailableVideoDevices}" SelectedItem="{Binding KaraokeVideoDevice}" DisplayMemberPath="DisplayName" Width="320" HorizontalAlignment="Left"/>
                                 <CheckBox Content="Enable Video Caching" IsChecked="{Binding EnableVideoCaching}" Foreground="White"/>
                                 <TextBlock Text="Video Cache Path" Foreground="White"/>
-                                <StackPanel Orientation="Horizontal" Spacing="6">
+                                <controls:SpacingStackPanel Orientation="Horizontal" Spacing="6">
                                     <TextBox Text="{Binding VideoCachePath}" Width="320"/>
                                     <Button Content="Browse" Width="80" Command="{Binding BrowseVideoCachePathCommand}"/>
-                                </StackPanel>
+                                </controls:SpacingStackPanel>
                                 <TextBlock Text="Cache Size (GB)" Foreground="White"/>
                                 <TextBox Text="{Binding CacheSizeGB}" Width="120" HorizontalAlignment="Left"/>
-                            </StackPanel>
+                            </controls:SpacingStackPanel>
                         </GroupBox>
-                    </StackPanel>
+                    </controls:SpacingStackPanel>
                 </ScrollViewer>
             </TabItem>
 
             <TabItem Header="DJ">
                 <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <StackPanel Margin="12" Spacing="12">
+                    <controls:SpacingStackPanel Margin="12" Spacing="12">
                         <GroupBox Header="DJ Preferences" Foreground="White">
-                            <StackPanel Margin="10" Spacing="8">
+                            <controls:SpacingStackPanel Margin="10" Spacing="8">
                                 <TextBlock Text="Default DJ Name" Foreground="White"/>
                                 <TextBox Text="{Binding DefaultDJName}" Width="320" HorizontalAlignment="Left"/>
                                 <CheckBox Content="Maximized on Start" IsChecked="{Binding MaximizedOnStart}" Foreground="White"/>
@@ -84,9 +85,9 @@
                                 </ComboBox>
                                 <CheckBox Content="{Binding TestMode, Converter={StaticResource TestModeConverter}}"
                                           IsChecked="{Binding TestMode}" Foreground="White"/>
-                            </StackPanel>
+                            </controls:SpacingStackPanel>
                         </GroupBox>
-                    </StackPanel>
+                    </controls:SpacingStackPanel>
                 </ScrollViewer>
             </TabItem>
 
@@ -95,9 +96,9 @@
             </TabItem>
         </TabControl>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+        <controls:SpacingStackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
             <Button Content="Save" Width="100" Height="32" Command="{Binding SaveSettingsCommand}"/>
             <Button Content="Cancel" Width="100" Height="32" Command="{Binding CancelCommand}"/>
-        </StackPanel>
+        </controls:SpacingStackPanel>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- add a custom `SpacingStackPanel` control that preserves child margins while injecting spacing
- replace unsupported `Spacing` attributes in the settings views with the new control to restore builds

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: dotnet SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00bedf0e083238d39851b90761453