### PR TITLE
Fix missing namespace for FontWeight usage

### DIFF
--- a/BNKaraoke.DJ/ViewModels/Settings/OverlaySettingsViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/Settings/OverlaySettingsViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Windows;
 using System.Windows.Media;
 
 namespace BNKaraoke.DJ.ViewModels.Settings


### PR DESCRIPTION
## Summary
- add the System.Windows namespace import so FontWeight resolves during compilation

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e00d24baa48323b0f74a104b9d99a5