### PR TITLE
Fix overlay font handling build issues

### DIFF
--- a/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Overlays.cs
+++ b/BNKaraoke.DJ/ViewModels/DJScreenViewModel.Overlays.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;

--- a/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
@@ -265,12 +265,18 @@ namespace BNKaraoke.DJ.ViewModels.Overlays
             {
                 try
                 {
-                    return (FontWeight)_fontWeightConverter.ConvertFromInvariantString(FontWeightName);
+                    var converted = _fontWeightConverter.ConvertFromInvariantString(FontWeightName);
+                    if (converted is FontWeight fontWeight)
+                    {
+                        return fontWeight;
+                    }
                 }
                 catch
                 {
-                    return FontWeights.Bold;
+                    // Swallow and fall back to default below.
                 }
+
+                return FontWeights.Bold;
             }
         }
 


### PR DESCRIPTION
## Summary
- add missing System namespace import for overlay view model wiring
- guard font weight conversion against null results to satisfy nullable analysis

## Testing
- dotnet build BNKaraoke.sln *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e00db947c08323844818f8f2bc11f9