### PR TITLE
Fix missing Encoding namespace

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;


### PR DESCRIPTION
## Summary
- add the System.Text namespace import so the Encoding references compile in VideoPlayerWindow

## Testing
- dotnet build (fails: dotnet command not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e02873d1c48323902f0f567710f65d