### PR TITLE
Fix video window show errors when maximized

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -344,12 +344,18 @@ namespace BNKaraoke.DJ.Views
 
         private void ShowWindowSafely()
         {
-            var wasShowActivated = ShowActivated;
-            var requiresActivationToggle = !wasShowActivated && WindowState == WindowState.Maximized;
-
-            if (requiresActivationToggle)
+            if (IsVisible)
             {
-                ShowActivated = true;
+                return;
+            }
+
+            var originalShowActivated = ShowActivated;
+            var originalWindowState = WindowState;
+            var requiresWindowStateToggle = !originalShowActivated && originalWindowState == WindowState.Maximized;
+
+            if (requiresWindowStateToggle)
+            {
+                WindowState = WindowState.Normal;
             }
 
             try
@@ -358,16 +364,23 @@ namespace BNKaraoke.DJ.Views
             }
             finally
             {
-                if (requiresActivationToggle)
+                Dispatcher.BeginInvoke(new Action(() =>
                 {
-                    Dispatcher.BeginInvoke(new Action(() =>
+                    if (!IsLoaded)
                     {
-                        if (IsLoaded)
-                        {
-                            ShowActivated = false;
-                        }
-                    }), DispatcherPriority.Background);
-                }
+                        return;
+                    }
+
+                    if (requiresWindowStateToggle && WindowState != originalWindowState)
+                    {
+                        WindowState = originalWindowState;
+                    }
+
+                    if (ShowActivated != originalShowActivated)
+                    {
+                        ShowActivated = originalShowActivated;
+                    }
+                }), DispatcherPriority.Background);
             }
         }
 


### PR DESCRIPTION
## Summary
- update the video player window show helper to avoid WPF exceptions when the window is maximized without activation
- normalize and restore the window state while keeping the original ShowActivated behavior and skipping redundant show calls

## Testing
- `dotnet test` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e035e29f0c832392c55f2f3059ce31