### PR TITLE
Improve settings labels and layout

### DIFF
--- a/BNKaraoke.DJ/Views/Settings/OverlaySettingsView.xaml
+++ b/BNKaraoke.DJ/Views/Settings/OverlaySettingsView.xaml
@@ -104,9 +104,12 @@
                                     Value="{Binding Overlay.BackgroundOpacity, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <TextBlock Text="{Binding Overlay.BackgroundOpacity, StringFormat=F2}" Foreground="White" Width="60" />
                         </controls:SpacingStackPanel>
-                        <CheckBox Content="Use gradient"
-                                  IsChecked="{Binding Overlay.UseGradient, Mode=TwoWay}"
-                                  Foreground="White" />
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                            <Label Content="Use gradient" Target="{Binding ElementName=UseGradientCheckBox}" Foreground="White" Width="120" />
+                            <CheckBox x:Name="UseGradientCheckBox"
+                                      IsChecked="{Binding Overlay.UseGradient, Mode=TwoWay}"
+                                      Foreground="White" />
+                        </controls:SpacingStackPanel>
                         <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <Label Content="Primary" Foreground="White" Width="80" Target="{Binding ElementName=PrimaryColorTextBox}" VerticalAlignment="Center" />
                             <TextBox x:Name="PrimaryColorTextBox" Width="120" Text="{Binding Overlay.PrimaryColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -161,12 +164,18 @@
                             <TextBox x:Name="TextColorTextBox" Width="120" Text="{Binding Overlay.FontColor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             <Border Width="32" Height="32" CornerRadius="4" BorderBrush="White" BorderThickness="1" Background="{Binding Overlay.FontBrush}" />
                         </controls:SpacingStackPanel>
-                        <CheckBox Content="Enable stroke"
-                                  IsChecked="{Binding Overlay.IsStrokeEnabled, Mode=TwoWay}"
-                                  Foreground="White" />
-                        <CheckBox Content="Enable shadow"
-                                  IsChecked="{Binding Overlay.IsShadowEnabled, Mode=TwoWay}"
-                                  Foreground="White" />
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                            <Label Content="Enable stroke" Target="{Binding ElementName=EnableStrokeCheckBox}" Foreground="White" Width="120" />
+                            <CheckBox x:Name="EnableStrokeCheckBox"
+                                      IsChecked="{Binding Overlay.IsStrokeEnabled, Mode=TwoWay}"
+                                      Foreground="White" />
+                        </controls:SpacingStackPanel>
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                            <Label Content="Enable shadow" Target="{Binding ElementName=EnableShadowCheckBox}" Foreground="White" Width="120" />
+                            <CheckBox x:Name="EnableShadowCheckBox"
+                                      IsChecked="{Binding Overlay.IsShadowEnabled, Mode=TwoWay}"
+                                      Foreground="White" />
+                        </controls:SpacingStackPanel>
                     </controls:SpacingStackPanel>
                 </GroupBox>
 
@@ -231,9 +240,12 @@
 
                 <GroupBox Header="Marquee" Foreground="White">
                     <controls:SpacingStackPanel Margin="10" Spacing="10">
-                        <CheckBox Content="Enable marquee"
-                                  IsChecked="{Binding Overlay.MarqueeEnabled, Mode=TwoWay}"
-                                  Foreground="White" />
+                        <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                            <Label Content="Enable marquee" Target="{Binding ElementName=EnableMarqueeCheckBox}" Foreground="White" Width="140" />
+                            <CheckBox x:Name="EnableMarqueeCheckBox"
+                                      IsChecked="{Binding Overlay.MarqueeEnabled, Mode=TwoWay}"
+                                      Foreground="White" />
+                        </controls:SpacingStackPanel>
                         <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                             <Label Content="Speed (px/s)" Foreground="White" Width="120" Target="{Binding ElementName=MarqueeSpeedSlider}" VerticalAlignment="Center" />
                             <Slider x:Name="MarqueeSpeedSlider"
@@ -270,9 +282,12 @@
 
                 <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10">
                     <TextBlock Text="{Binding PreviewModeLabel}" Foreground="White" VerticalAlignment="Center" />
-                    <CheckBox Content="Blue screen"
-                              IsChecked="{Binding IsBluePreview, Mode=TwoWay}"
-                              Foreground="White" />
+                    <controls:SpacingStackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                        <Label Content="Blue screen" Target="{Binding ElementName=BlueScreenPreviewCheckBox}" Foreground="White" />
+                        <CheckBox x:Name="BlueScreenPreviewCheckBox"
+                                  IsChecked="{Binding IsBluePreview, Mode=TwoWay}"
+                                  Foreground="White" />
+                    </controls:SpacingStackPanel>
                 </controls:SpacingStackPanel>
 
                 <Grid Grid.Row="1" Margin="0,10,0,0">

--- a/BNKaraoke.DJ/Views/SettingsWindow.xaml
+++ b/BNKaraoke.DJ/Views/SettingsWindow.xaml
@@ -5,8 +5,8 @@
         xmlns:controls="clr-namespace:BNKaraoke.DJ.Controls"
         xmlns:settingsViews="clr-namespace:BNKaraoke.DJ.Views.Settings"
         Title="Settings"
-        Height="900"
-        Width="1300"
+        Height="810"
+        Width="1400"
         MinHeight="720"
         MinWidth="1024"
         WindowStartupLocation="CenterScreen"
@@ -34,13 +34,22 @@
                                     <Button Content="Add" Width="60" Command="{Binding AddApiUrlCommand}"/>
                                     <Button Content="Remove" Width="80" Command="{Binding RemoveApiUrlCommand}"/>
                                 </controls:SpacingStackPanel>
-                                <CheckBox Content="Enable SignalR Sync" IsChecked="{Binding EnableSignalRSync}" Foreground="White"/>
+                                <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                                    <Label Content="Enable SignalR Sync" Target="{Binding ElementName=EnableSignalRSyncCheckBox}" Foreground="White" Width="220"/>
+                                    <CheckBox x:Name="EnableSignalRSyncCheckBox" IsChecked="{Binding EnableSignalRSync}" Foreground="White"/>
+                                </controls:SpacingStackPanel>
                                 <Label Content="SignalR Hub URL" Target="{Binding ElementName=SignalRHubUrlTextBox}" Foreground="White"/>
                                 <TextBox x:Name="SignalRHubUrlTextBox" Text="{Binding SignalRHubUrl}" Width="300" HorizontalAlignment="Left"/>
                                 <Label Content="Reconnect Interval (ms)" Target="{Binding ElementName=ReconnectIntervalTextBox}" Foreground="White"/>
                                 <TextBox x:Name="ReconnectIntervalTextBox" Text="{Binding ReconnectIntervalMs}" Width="120" HorizontalAlignment="Left"/>
-                                <CheckBox Content="Show Debug Console" IsChecked="{Binding ShowDebugConsole}" Foreground="White"/>
-                                <CheckBox Content="Enable Verbose Logging" IsChecked="{Binding EnableVerboseLogging}" Foreground="White"/>
+                                <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                                    <Label Content="Show Debug Console" Target="{Binding ElementName=ShowDebugConsoleCheckBox}" Foreground="White" Width="220"/>
+                                    <CheckBox x:Name="ShowDebugConsoleCheckBox" IsChecked="{Binding ShowDebugConsole}" Foreground="White"/>
+                                </controls:SpacingStackPanel>
+                                <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                                    <Label Content="Enable Verbose Logging" Target="{Binding ElementName=EnableVerboseLoggingCheckBox}" Foreground="White" Width="220"/>
+                                    <CheckBox x:Name="EnableVerboseLoggingCheckBox" IsChecked="{Binding EnableVerboseLogging}" Foreground="White"/>
+                                </controls:SpacingStackPanel>
                                 <Label Content="Log File Path" Target="{Binding ElementName=LogFilePathTextBox}" Foreground="White"/>
                                 <controls:SpacingStackPanel Orientation="Horizontal" Spacing="6">
                                     <TextBox x:Name="LogFilePathTextBox" Text="{Binding LogFilePath}" Width="320"/>
@@ -61,7 +70,10 @@
                                 <ComboBox x:Name="PreferredAudioDeviceComboBox" ItemsSource="{Binding AvailableAudioDevices}" SelectedItem="{Binding PreferredAudioDevice}" DisplayMemberPath="DisplayName" Width="320" HorizontalAlignment="Left"/>
                                 <Label Content="Karaoke Video Device" Target="{Binding ElementName=KaraokeVideoDeviceComboBox}" Foreground="White"/>
                                 <ComboBox x:Name="KaraokeVideoDeviceComboBox" ItemsSource="{Binding AvailableVideoDevices}" SelectedItem="{Binding KaraokeVideoDevice}" DisplayMemberPath="DisplayName" Width="320" HorizontalAlignment="Left"/>
-                                <CheckBox Content="Enable Video Caching" IsChecked="{Binding EnableVideoCaching}" Foreground="White"/>
+                                <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                                    <Label Content="Enable Video Caching" Target="{Binding ElementName=EnableVideoCachingCheckBox}" Foreground="White" Width="220"/>
+                                    <CheckBox x:Name="EnableVideoCachingCheckBox" IsChecked="{Binding EnableVideoCaching}" Foreground="White"/>
+                                </controls:SpacingStackPanel>
                                 <Label Content="Video Cache Path" Target="{Binding ElementName=VideoCachePathTextBox}" Foreground="White"/>
                                 <controls:SpacingStackPanel Orientation="Horizontal" Spacing="6">
                                     <TextBox x:Name="VideoCachePathTextBox" Text="{Binding VideoCachePath}" Width="320"/>
@@ -82,15 +94,23 @@
                             <controls:SpacingStackPanel Margin="10" Spacing="8">
                                 <Label Content="Default DJ Name" Target="{Binding ElementName=DefaultDjNameTextBox}" Foreground="White"/>
                                 <TextBox x:Name="DefaultDjNameTextBox" Text="{Binding DefaultDJName}" Width="320" HorizontalAlignment="Left"/>
-                                <CheckBox Content="Maximized on Start" IsChecked="{Binding MaximizedOnStart}" Foreground="White"/>
+                                <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                                    <Label Content="Maximized on Start" Target="{Binding ElementName=MaximizedOnStartCheckBox}" Foreground="White" Width="220"/>
+                                    <CheckBox x:Name="MaximizedOnStartCheckBox" IsChecked="{Binding MaximizedOnStart}" Foreground="White"/>
+                                </controls:SpacingStackPanel>
                                 <Label Content="Theme" Target="{Binding ElementName=ThemeComboBox}" Foreground="White"/>
                                 <ComboBox x:Name="ThemeComboBox" SelectedItem="{Binding Theme}" Width="200" HorizontalAlignment="Left">
                                     <ComboBoxItem>Dark</ComboBoxItem>
                                     <ComboBoxItem>Light</ComboBoxItem>
                                     <ComboBoxItem>Auto</ComboBoxItem>
                                 </ComboBox>
-                                <CheckBox Content="{Binding TestMode, Converter={StaticResource TestModeConverter}}"
-                                          IsChecked="{Binding TestMode}" Foreground="White"/>
+                                <controls:SpacingStackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="10">
+                                    <Label Content="Application Mode" Target="{Binding ElementName=TestModeCheckBox}" Foreground="White" Width="220"/>
+                                    <CheckBox x:Name="TestModeCheckBox"
+                                              Content="{Binding TestMode, Converter={StaticResource TestModeConverter}}"
+                                              IsChecked="{Binding TestMode}"
+                                              Foreground="White"/>
+                                </controls:SpacingStackPanel>
                             </controls:SpacingStackPanel>
                         </GroupBox>
                     </controls:SpacingStackPanel>


### PR DESCRIPTION
## Summary
- add explicit label elements for checkbox-based settings across the general, devices, DJ, and overlay tabs
- widen the settings window while slightly reducing its height to keep the footer buttons visible

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3bcda21008323bee3de4ca427799a