### PR TITLE
Fix settings tab labels and balance overlay preview

### DIFF
--- a/BNKaraoke.DJ/Styles/Styles.xaml
+++ b/BNKaraoke.DJ/Styles/Styles.xaml
@@ -3,4 +3,30 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:local="clr-namespace:BNKaraoke.DJ.Converters">
     <local:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+
+    <Style TargetType="TabControl">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="#1F2937" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="#E5E7EB" />
+    </Style>
+
+    <Style TargetType="TabItem">
+        <Setter Property="Foreground" Value="#E5E7EB" />
+        <Setter Property="FontWeight" Value="SemiBold" />
+        <Setter Property="Padding" Value="16,8" />
+        <Setter Property="Margin" Value="0,0,6,0" />
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="#FFFFFF" />
+            </Trigger>
+            <Trigger Property="IsSelected" Value="True">
+                <Setter Property="Foreground" Value="#FFFFFF" />
+                <Setter Property="Background" Value="#1F3560" />
+                <Setter Property="BorderBrush" Value="#3B82F6" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
 </ResourceDictionary>

--- a/BNKaraoke.DJ/Views/Settings/OverlaySettingsView.xaml
+++ b/BNKaraoke.DJ/Views/Settings/OverlaySettingsView.xaml
@@ -17,13 +17,13 @@
 
     <Grid Margin="0">
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*" />
+            <ColumnDefinition Width="*" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
         <ScrollViewer Grid.Column="0"
                       VerticalScrollBarVisibility="Auto"
-                      Margin="0,0,15,0">
+                      Margin="0,0,12,0">
             <controls:SpacingStackPanel Orientation="Vertical" Spacing="12">
                 <GroupBox Header="Bands" Foreground="White">
                     <controls:SpacingStackPanel Margin="10" Spacing="10">
@@ -273,7 +273,7 @@
             </controls:SpacingStackPanel>
         </ScrollViewer>
 
-        <GroupBox Grid.Column="1" Header="Preview" Foreground="White">
+        <GroupBox Grid.Column="1" Header="Preview" Foreground="White" Margin="12,0,0,0">
             <Grid Margin="10">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />


### PR DESCRIPTION
## Summary
- add shared styles so tab headers render with high contrast text
- adjust overlay settings grid to give settings and preview equal width and consistent spacing

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3c04314cc8323838de56977fa31f8