### PR TITLE
Ensure video window normalizes before showing

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -449,7 +449,7 @@ namespace BNKaraoke.DJ.Views
 
             var originalShowActivated = ShowActivated;
             var originalWindowState = WindowState;
-            var requiresWindowStateToggle = !originalShowActivated && originalWindowState == WindowState.Maximized;
+            var requiresWindowStateToggle = originalWindowState == WindowState.Maximized;
             var requiresActivationToggle = !originalShowActivated;
 
             if (requiresWindowStateToggle)


### PR DESCRIPTION
## Summary
- normalize the video player window before showing it to avoid WPF maximized activation errors
- restore the original window state after the window is displayed

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3cabe6a8083239272a69df06327c3