### PR TITLE
Handle maximized show when window is no-activate

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -449,7 +449,7 @@ namespace BNKaraoke.DJ.Views
 
             var originalShowActivated = ShowActivated;
             var originalWindowState = WindowState;
-            var requiresWindowStateToggle = originalWindowState == WindowState.Maximized;
+            var requiresWindowStateToggle = originalWindowState != WindowState.Normal;
             var requiresActivationToggle = !originalShowActivated;
 
             if (requiresWindowStateToggle)
@@ -464,7 +464,28 @@ namespace BNKaraoke.DJ.Views
 
             try
             {
-                base.Show();
+                try
+                {
+                    base.Show();
+                }
+                catch (InvalidOperationException ex) when (ex.Message.Contains("ShowActivated is false", StringComparison.Ordinal))
+                {
+                    Log.Warning("[VIDEO PLAYER] Retrying window show after activation/window state adjustment: {Message}", ex.Message);
+
+                    if (!requiresWindowStateToggle && WindowState != WindowState.Normal)
+                    {
+                        WindowState = WindowState.Normal;
+                        requiresWindowStateToggle = true;
+                    }
+
+                    if (!requiresActivationToggle)
+                    {
+                        ShowActivated = true;
+                        requiresActivationToggle = true;
+                    }
+
+                    base.Show();
+                }
             }
             finally
             {


### PR DESCRIPTION
## Summary
- normalize the video window state before showing when it might be maximized or minimized
- retry showing the window with activation temporarily enabled if WPF rejects the initial call
- keep restoring the original window state and activation preference after the show completes

## Testing
- dotnet build BNKaraoke.sln *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3cd56acd483238e1ba6638ed56d34