### PR TITLE
Replace video side panel with gradient borders

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -17,6 +17,14 @@
             <GradientStop Color="#1e3a8a" Offset="0"/>
             <GradientStop Color="#3b82f6" Offset="1"/>
         </LinearGradientBrush>
+        <LinearGradientBrush x:Key="LeftEdgeBrush" StartPoint="0,0" EndPoint="1,0">
+            <GradientStop Color="#CC000000" Offset="0"/>
+            <GradientStop Color="#00000000" Offset="1"/>
+        </LinearGradientBrush>
+        <LinearGradientBrush x:Key="RightEdgeBrush" StartPoint="1,0" EndPoint="0,0">
+            <GradientStop Color="#CC000000" Offset="0"/>
+            <GradientStop Color="#00000000" Offset="1"/>
+        </LinearGradientBrush>
     </Window.Resources>
     <Grid Background="{StaticResource WindowBackground}"
           DataContext="{x:Static viewModels:OverlayViewModel.Instance}"
@@ -52,92 +60,28 @@
               ClipToBounds="True"
               FocusVisualStyle="{x:Null}"
               Focusable="False">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-            </Grid.ColumnDefinitions>
-
-            <Border Grid.Column="0"
-                    Width="360"
-                    Background="{Binding SidePanelBrush}"
-                    Visibility="{Binding SidePanelVisibility}"
-                    Padding="24"
-                    SnapsToDevicePixels="True"
-                    Focusable="False"
-                    IsHitTestVisible="False">
-                <StackPanel>
-                    <TextBlock Text="{Binding SidePanelClock}"
-                               Foreground="#E6FFFFFF"
-                               FontSize="28"
-                               FontWeight="SemiBold"
-                               Margin="0,0,0,12"/>
-                    <TextBlock Text="{Binding EventNameDisplay}"
-                               Foreground="White"
-                               FontSize="30"
-                               FontWeight="Bold"
-                               TextWrapping="Wrap"
-                               Margin="0,0,0,4"/>
-                    <TextBlock Text="{Binding EventVenueDisplay}"
-                               Foreground="#CCFFFFFF"
-                               FontSize="20"
-                               TextWrapping="Wrap"
-                               Margin="0,0,0,24"/>
-
-                    <Rectangle Height="1"
-                               Fill="#40FFFFFF"
-                               Margin="0,0,0,20"/>
-
-                    <TextBlock Text="Now Playing"
-                               Foreground="#CCFFFFFF"
-                               FontSize="18"
-                               FontWeight="SemiBold"
-                               TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding NowPlayingPrimary}"
-                               Foreground="White"
-                               FontSize="24"
-                               FontWeight="Bold"
-                               TextWrapping="Wrap"
-                               Margin="0,4,0,2"/>
-                    <TextBlock Text="{Binding NowPlayingSecondary}"
-                               Foreground="#E6FFFFFF"
-                               FontSize="18"
-                               TextWrapping="Wrap"
-                               Margin="0,0,0,20"/>
-
-                    <Rectangle Height="1"
-                               Fill="#26FFFFFF"
-                               Margin="0,0,0,20"/>
-
-                    <TextBlock Text="Up Next"
-                               Foreground="#CCFFFFFF"
-                               FontSize="18"
-                               FontWeight="SemiBold"
-                               TextWrapping="Wrap"/>
-                    <TextBlock Text="{Binding UpNextPrimary}"
-                               Foreground="White"
-                               FontSize="24"
-                               FontWeight="Bold"
-                               TextWrapping="Wrap"
-                               Margin="0,4,0,2"/>
-                    <TextBlock Text="{Binding UpNextSecondary}"
-                               Foreground="#E6FFFFFF"
-                               FontSize="18"
-                               TextWrapping="Wrap"/>
-                </StackPanel>
-            </Border>
-
-            <vlc:VideoView Grid.Column="1"
-                           x:Name="VideoPlayer"
+            <vlc:VideoView x:Name="VideoPlayer"
                            HorizontalAlignment="Stretch"
                            VerticalAlignment="Stretch"
                            Margin="0"
                            Background="#000000"
                            Focusable="False"
                            FocusVisualStyle="{x:Null}"/>
+            <Rectangle Fill="{StaticResource LeftEdgeBrush}"
+                       Width="180"
+                       HorizontalAlignment="Left"
+                       VerticalAlignment="Stretch"
+                       IsHitTestVisible="False"
+                       Panel.ZIndex="1"/>
+            <Rectangle Fill="{StaticResource RightEdgeBrush}"
+                       Width="180"
+                       HorizontalAlignment="Right"
+                       VerticalAlignment="Stretch"
+                       IsHitTestVisible="False"
+                       Panel.ZIndex="1"/>
             <Grid x:Name="TitleOverlay"
-                  Grid.ColumnSpan="2"
                   Background="{StaticResource WindowBackground}"
-                  Panel.ZIndex="1"
+                  Panel.ZIndex="2"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Stretch">
                 <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- remove the informational side panel from the now playing window
- overlay matching gradient borders on the left and right edges of the video player
- keep the title overlay above the gradients for branding visibility

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e3e1b9528483238378bd41a8d3380e