### PR TITLE
Fix idle state display for the karaoke video player

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -72,13 +72,35 @@
                        HorizontalAlignment="Left"
                        VerticalAlignment="Stretch"
                        IsHitTestVisible="False"
-                       Panel.ZIndex="1"/>
+                       Panel.ZIndex="1">
+                <Rectangle.Style>
+                    <Style TargetType="Rectangle">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsBlueState}" Value="True">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Rectangle.Style>
+            </Rectangle>
             <Rectangle Fill="{StaticResource RightEdgeBrush}"
                        Width="180"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Stretch"
                        IsHitTestVisible="False"
-                       Panel.ZIndex="1"/>
+                       Panel.ZIndex="1">
+                <Rectangle.Style>
+                    <Style TargetType="Rectangle">
+                        <Setter Property="Visibility" Value="Collapsed"/>
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsBlueState}" Value="True">
+                                <Setter Property="Visibility" Value="Visible"/>
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Rectangle.Style>
+            </Rectangle>
             <Grid x:Name="TitleOverlay"
                   Background="{StaticResource WindowBackground}"
                   Panel.ZIndex="2"


### PR DESCRIPTION
## Summary
- hide the edge gradient rectangles while playback is active so the left-side white bar disappears
- centralize blue-brand overlay handling and respond to LibVLC player state changes so the idle screen reliably shows the branded QR layout

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3e3abda1083238c1ba39f21b2d009