### PR TITLE
Fix video player gradients and idle transition flicker

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -18,12 +18,12 @@
             <GradientStop Color="#3b82f6" Offset="1"/>
         </LinearGradientBrush>
         <LinearGradientBrush x:Key="LeftEdgeBrush" StartPoint="0,0" EndPoint="1,0">
-            <GradientStop Color="#CC000000" Offset="0"/>
-            <GradientStop Color="#00000000" Offset="1"/>
+            <GradientStop Color="#CC1e3a8a" Offset="0"/>
+            <GradientStop Color="#003b82f6" Offset="1"/>
         </LinearGradientBrush>
         <LinearGradientBrush x:Key="RightEdgeBrush" StartPoint="1,0" EndPoint="0,0">
-            <GradientStop Color="#CC000000" Offset="0"/>
-            <GradientStop Color="#00000000" Offset="1"/>
+            <GradientStop Color="#CC1e3a8a" Offset="0"/>
+            <GradientStop Color="#003b82f6" Offset="1"/>
         </LinearGradientBrush>
     </Window.Resources>
     <Grid Background="{StaticResource WindowBackground}"
@@ -56,7 +56,7 @@
 
         <Grid Grid.Row="1"
               x:Name="VideoHost"
-              Background="Black"
+              Background="Transparent"
               ClipToBounds="True"
               FocusVisualStyle="{x:Null}"
               Focusable="False">
@@ -72,35 +72,13 @@
                        HorizontalAlignment="Left"
                        VerticalAlignment="Stretch"
                        IsHitTestVisible="False"
-                       Panel.ZIndex="1">
-                <Rectangle.Style>
-                    <Style TargetType="Rectangle">
-                        <Setter Property="Visibility" Value="Collapsed"/>
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsBlueState}" Value="True">
-                                <Setter Property="Visibility" Value="Visible"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Rectangle.Style>
-            </Rectangle>
+                       Panel.ZIndex="1"/>
             <Rectangle Fill="{StaticResource RightEdgeBrush}"
                        Width="180"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Stretch"
                        IsHitTestVisible="False"
-                       Panel.ZIndex="1">
-                <Rectangle.Style>
-                    <Style TargetType="Rectangle">
-                        <Setter Property="Visibility" Value="Collapsed"/>
-                        <Style.Triggers>
-                            <DataTrigger Binding="{Binding IsBlueState}" Value="True">
-                                <Setter Property="Visibility" Value="Visible"/>
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Rectangle.Style>
-            </Rectangle>
+                       Panel.ZIndex="1"/>
             <Grid x:Name="TitleOverlay"
                   Background="{StaticResource WindowBackground}"
                   Panel.ZIndex="2"

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -1393,8 +1393,8 @@ namespace BNKaraoke.DJ.Views
             void Apply()
             {
                 TitleOverlay.Visibility = Visibility.Visible;
-                VideoPlayer.Visibility = Visibility.Hidden;
-                VideoPlayer.Opacity = 1;
+                VideoPlayer.Visibility = Visibility.Visible;
+                VideoPlayer.Opacity = 0;
                 OverlayViewModel.Instance.IsBlueState = true;
             }
 


### PR DESCRIPTION
## Summary
- tint the video player side overlays with the brand blue gradient and allow the host grid to show the background
- keep the VLC surface visible while showing the idle screen so transitions no longer flicker

## Testing
- `dotnet test BNKaraoke.sln` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f241aec08323a91346c0970e7e35