### PR TITLE
Fix VideoPlayerWindow resource lookup

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -12,7 +12,7 @@
         WindowState="Maximized"
         WindowStyle="None"
         WindowStartupLocation="Manual"
-        Background="{StaticResource WindowBackground}">
+        Background="{DynamicResource WindowBackground}">
     <Window.Resources>
         <LinearGradientBrush x:Key="WindowBackground" StartPoint="0,0" EndPoint="0,1">
             <GradientStop Color="#1e3a8a" Offset="0"/>


### PR DESCRIPTION
## Summary
- use a dynamic resource lookup for the VideoPlayerWindow background brush so the window can initialize before resources are created

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3fac768448323b1a813fbf8bb3b40