### PR TITLE
Fix initial edge gradient rendering in video player

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -68,13 +68,15 @@
                            Background="#000000"
                            Focusable="False"
                            FocusVisualStyle="{x:Null}"/>
-            <Rectangle Fill="{StaticResource LeftEdgeBrush}"
+            <Rectangle x:Name="LeftEdgeOverlay"
+                       Fill="{StaticResource LeftEdgeBrush}"
                        Width="180"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Stretch"
                        IsHitTestVisible="False"
                        Panel.ZIndex="1"/>
-            <Rectangle Fill="{StaticResource RightEdgeBrush}"
+            <Rectangle x:Name="RightEdgeOverlay"
+                       Fill="{StaticResource RightEdgeBrush}"
                        Width="180"
                        HorizontalAlignment="Right"
                        VerticalAlignment="Stretch"

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -13,6 +13,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Shapes;
 using System.Windows.Threading;
 
 namespace BNKaraoke.DJ.Views
@@ -414,6 +416,7 @@ namespace BNKaraoke.DJ.Views
                 WindowStartupLocation = WindowStartupLocation.Manual;
                 CaptureControllerWindowHandle();
                 InitializeComponent();
+                RefreshEdgeGradients();
                 OverlayViewModel.Instance.IsBlueState = true;
                 ShowIdleScreen();
 
@@ -1391,6 +1394,7 @@ namespace BNKaraoke.DJ.Views
                 VideoPlayer.Visibility = Visibility.Visible;
                 VideoPlayer.Opacity = 1;
                 OverlayViewModel.Instance.IsBlueState = false;
+                RefreshEdgeGradients();
             }
 
             if (!Dispatcher.CheckAccess())
@@ -1420,6 +1424,44 @@ namespace BNKaraoke.DJ.Views
             else
             {
                 Apply();
+            }
+        }
+
+        private void RefreshEdgeGradients()
+        {
+            void Apply()
+            {
+                ApplyEdgeBrush(LeftEdgeOverlay, "LeftEdgeBrush");
+                ApplyEdgeBrush(RightEdgeOverlay, "RightEdgeBrush");
+            }
+
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.Invoke(Apply);
+            }
+            else
+            {
+                Apply();
+            }
+        }
+
+        private void ApplyEdgeBrush(Rectangle target, string resourceKey)
+        {
+            if (target == null)
+            {
+                return;
+            }
+
+            if (TryFindResource(resourceKey) is Brush brush)
+            {
+                if (brush is Freezable freezable)
+                {
+                    target.Fill = (Brush)freezable.Clone();
+                }
+                else
+                {
+                    target.Fill = brush;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- name the video surface edge overlay rectangles so they can be updated at runtime
- refresh the edge gradient brushes whenever the playback surface becomes visible to ensure gradients render on first play

## Testing
- Not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3fbeccffc8323889870183e049dde