### PR TITLE
Resolve LibVLC path resolution build errors

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
-using System.Windows.Shapes;
 using System.Windows.Threading;
 
 namespace BNKaraoke.DJ.Views
@@ -189,20 +188,20 @@ namespace BNKaraoke.DJ.Views
                 return null;
             }
 
-            var rootDirectoryName = Path.GetFileName(root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            var rootDirectoryName = Path.GetFileName(root!.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
             if (!string.IsNullOrWhiteSpace(rootDirectoryName) &&
                 rootDirectoryName.Equals("plugins", StringComparison.OrdinalIgnoreCase))
             {
-                return root;
+                return root!;
             }
 
-            var directPlugins = Path.Combine(root, "plugins");
+            var directPlugins = Path.Combine(root!, "plugins");
             if (Directory.Exists(directPlugins))
             {
                 return directPlugins;
             }
 
-            var vlcPlugins = Path.Combine(root, "vlc", "plugins");
+            var vlcPlugins = Path.Combine(root!, "vlc", "plugins");
             if (Directory.Exists(vlcPlugins))
             {
                 return vlcPlugins;


### PR DESCRIPTION
## Summary
- remove the unnecessary System.Windows.Shapes Path import to prevent ambiguity with System.IO.Path
- ensure LibVLC plugin path helpers treat the incoming root as non-null after validation to silence nullability warnings

## Testing
- `dotnet build BNKaraoke.sln` *(fails: dotnet is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e404c48d4083239a279b1670a0f21e