### PR TITLE
Remove unused Shapes namespace causing Path ambiguity

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -14,7 +14,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
-using System.Windows.Shapes;
 using System.Windows.Threading;
 
 namespace BNKaraoke.DJ.Views


### PR DESCRIPTION
## Summary
- remove the unused System.Windows.Shapes namespace from VideoPlayerWindow.xaml.cs to eliminate the Path type ambiguity during builds

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e419755e08832383450ca85fb5ef50