### PR TITLE
Fix video player letterboxing background

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -57,7 +57,7 @@
 
         <Grid Grid.Row="1"
               x:Name="VideoHost"
-              Background="Transparent"
+              Background="#000000"
               ClipToBounds="True"
               FocusVisualStyle="{x:Null}"
               Focusable="False">
@@ -66,6 +66,8 @@
                            VerticalAlignment="Stretch"
                            Margin="0"
                            Background="#000000"
+                           Stretch="UniformToFill"
+                           StretchDirection="Both"
                            Focusable="False"
                            FocusVisualStyle="{x:Null}"/>
             <Border x:Name="LeftEdgeOverlay"


### PR DESCRIPTION
## Summary
- ensure the video host renders a black backdrop so that any letterboxing matches the gradients
- force the LibVLC video view to stretch uniformly and fill the viewport, removing white gutters around playback

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e43929e0388323ad7c3af6066c668d