### PR TITLE
Remove unsupported Stretch properties from VideoView

### DIFF
--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -66,8 +66,6 @@
                            VerticalAlignment="Stretch"
                            Margin="0"
                            Background="#000000"
-                           Stretch="UniformToFill"
-                           StretchDirection="Both"
                            Focusable="False"
                            FocusVisualStyle="{x:Null}"/>
             <Border x:Name="LeftEdgeOverlay"


### PR DESCRIPTION
## Summary
- remove the unsupported Stretch-related attributes from the VideoView control so the project builds again

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e43aa549e48323813a15e9d8026e3c