### PR TITLE
Fix marquee stretching within overlay bands

### DIFF
--- a/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml
+++ b/BNKaraoke.DJ/Views/Overlays/OverlayBand.xaml
@@ -15,7 +15,7 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
             SnapsToDevicePixels="True">
-        <ContentPresenter HorizontalAlignment="Center"
+        <ContentPresenter HorizontalAlignment="Stretch"
                           VerticalAlignment="Center"
                           Content="{Binding Content, RelativeSource={RelativeSource AncestorType=UserControl}}"
                           ContentTemplate="{Binding ContentTemplate, RelativeSource={RelativeSource AncestorType=UserControl}}"


### PR DESCRIPTION
## Summary
- allow overlay band content to stretch horizontally so marquees can measure the full band width
- resolves marquee text failing to scroll when the content is wider than the viewport

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e44e760e2483238b6697cb2909191a