### PR TITLE
Improve marquee looping continuity and add template regression test

### DIFF
--- a/BNKaraoke.DJ.Tests/OverlayTemplateEngineTests.cs
+++ b/BNKaraoke.DJ.Tests/OverlayTemplateEngineTests.cs
@@ -71,5 +71,21 @@ namespace BNKaraoke.DJ.Tests
 
             Assert.Equal("It is 9:30 PM", result);
         }
+
+        [Fact]
+        public void Render_PreservesExtendedMessaging()
+        {
+            var engine = new OverlayTemplateEngine();
+            var context = new OverlayTemplateContext
+            {
+                Brand = "BN Karaoke"
+            };
+
+            var template = "{Brand} • REQUEST A SONG AT {Brand} - Be sure to get your song request in Early !!! The song queue fills up quickly.";
+
+            var result = engine.Render(template, context);
+
+            Assert.Equal("BN Karaoke • REQUEST A SONG AT BN Karaoke - Be sure to get your song request in Early !!! The song queue fills up quickly.", result);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- split the marquee animation into entry and looping phases so duplicate text can overlap and remove the gap between cycles
- keep the loop transform cycling between identical visual states to eliminate the visible reset and resume from the entry position automatically
- add a template engine test to ensure long marquee messaging with placeholders renders the entire string

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e50c65d33883238fd4a5bd50e26cd4