### PR TITLE
Fix marquee entry offsets and add regression tests

### DIFF
--- a/BNKaraoke.DJ.Tests/MarqueePresenterTests.cs
+++ b/BNKaraoke.DJ.Tests/MarqueePresenterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -119,6 +120,112 @@ namespace BNKaraoke.DJ.Tests
 
                 Assert.Equal(0, nextLayer.Children.Count);
                 Assert.NotSame(originalVisual, currentLayer.Children[0]);
+
+                window.Close();
+            });
+        }
+
+        [WpfFact]
+        public async Task ShortTextStopsCenteredAfterEntryAnimationAsync()
+        {
+            await WpfTestHelper.RunAsync(async () =>
+            {
+                var presenter = new MarqueePresenter
+                {
+                    Width = 640,
+                    Height = 96,
+                    CrossfadeMs = 0,
+                    MarqueeSpeedPxPerSec = 180,
+                    SpacerWidthPx = 60,
+                    Margin = new Thickness(0)
+                };
+
+                var window = new Window
+                {
+                    Width = presenter.Width,
+                    Height = presenter.Height,
+                    Content = presenter,
+                    WindowStyle = WindowStyle.None,
+                    ShowInTaskbar = false,
+                    AllowsTransparency = true,
+                    Background = Brushes.Transparent
+                };
+
+                window.Show();
+                await WpfTestHelper.WaitForLoadedAsync(presenter);
+
+                presenter.Text = "Center me";
+                presenter.UpdateLayout();
+                await WpfTestHelper.WaitForIdleAsync(presenter.Dispatcher);
+
+                var currentLayer = (Grid)presenter.Template.FindName("PART_CurrentLayer", presenter);
+                var root = Assert.IsType<Grid>(currentLayer.Children[0]);
+                var content = Assert.IsAssignableFrom<FrameworkElement>(root.Children[0]);
+                var transform = Assert.IsType<TranslateTransform>(content.RenderTransform);
+
+                var availableWidth = presenter.ActualWidth;
+                var textWidth = content.ActualWidth;
+                var expectedOffset = Math.Max(0.0, (availableWidth - textWidth) / 2.0);
+                var travelDistance = Math.Abs(availableWidth - expectedOffset);
+                var durationSeconds = travelDistance / presenter.MarqueeSpeedPxPerSec;
+
+                await Task.Delay(TimeSpan.FromSeconds(durationSeconds + 0.3));
+                await WpfTestHelper.WaitForIdleAsync(presenter.Dispatcher);
+
+                var tolerance = 1.5;
+                Assert.InRange(transform.X, expectedOffset - tolerance, expectedOffset + tolerance);
+
+                window.Close();
+            });
+        }
+
+        [WpfFact]
+        public async Task LongTextBeginsOffScreenBeforeMarqueeLoopAsync()
+        {
+            await WpfTestHelper.RunAsync(async () =>
+            {
+                var presenter = new MarqueePresenter
+                {
+                    Width = 480,
+                    Height = 96,
+                    CrossfadeMs = 0,
+                    MarqueeSpeedPxPerSec = 90,
+                    SpacerWidthPx = 60,
+                    Margin = new Thickness(0)
+                };
+
+                var window = new Window
+                {
+                    Width = presenter.Width,
+                    Height = presenter.Height,
+                    Content = presenter,
+                    WindowStyle = WindowStyle.None,
+                    ShowInTaskbar = false,
+                    AllowsTransparency = true,
+                    Background = Brushes.Transparent
+                };
+
+                window.Show();
+                await WpfTestHelper.WaitForLoadedAsync(presenter);
+
+                var longText = new string('A', 200);
+                presenter.Text = longText;
+                presenter.UpdateLayout();
+                await WpfTestHelper.WaitForIdleAsync(presenter.Dispatcher);
+
+                var stateField = typeof(MarqueePresenter).GetField("_currentState", BindingFlags.Instance | BindingFlags.NonPublic);
+                Assert.NotNull(stateField);
+                var state = stateField!.GetValue(presenter);
+                Assert.NotNull(state);
+
+                var stateType = state!.GetType();
+                var initialOffset = (double?)stateType.GetProperty("InitialOffset")?.GetValue(state);
+                var finalOffset = (double?)stateType.GetProperty("FinalOffset")?.GetValue(state);
+                var isMarquee = (bool)stateType.GetProperty("IsMarquee")!.GetValue(state)!;
+
+                Assert.True(isMarquee);
+                Assert.True(initialOffset.HasValue && initialOffset.Value > 0);
+                Assert.Equal(0.0, finalOffset ?? 0.0, 3);
 
                 window.Close();
             });

--- a/BNKaraoke.DJ/Controls/MarqueePresenter.cs
+++ b/BNKaraoke.DJ/Controls/MarqueePresenter.cs
@@ -380,7 +380,7 @@ namespace BNKaraoke.DJ.Controls
                 var staticContent = CreateTextVisual(text, dropShadows);
                 staticContent.HorizontalAlignment = HorizontalAlignment.Center;
                 root.Children.Add(staticContent);
-                return new MarqueeVisualState(root, null, 0.0, 0.0, 0.0, null, null, dropShadows, null, false);
+                return new MarqueeVisualState(root, null, 0.0, 0.0, 0.0, null, null, dropShadows, null, null, false);
             }
 
             var baseSpeed = Math.Max(10.0, Math.Abs(MarqueeSpeedPxPerSec));
@@ -422,7 +422,18 @@ namespace BNKaraoke.DJ.Controls
                     targetOffset,
                     Math.Max(0.1, entryDurationSecondsCentered));
 
-                return new MarqueeVisualState(root, transform, 0.0, baseSpeed, Math.Max(0.1, entryDurationSecondsCentered), entryClockCentered, null, dropShadows, startOffset, false);
+                return new MarqueeVisualState(
+                    root,
+                    transform,
+                    0.0,
+                    baseSpeed,
+                    Math.Max(0.1, entryDurationSecondsCentered),
+                    entryClockCentered,
+                    null,
+                    dropShadows,
+                    startOffset,
+                    targetOffset,
+                    false);
             }
 
             var stackPanel = new StackPanel
@@ -511,6 +522,7 @@ namespace BNKaraoke.DJ.Controls
                 loopClock,
                 dropShadows,
                 entryDistance > 0.0 ? availableWidth : 0.0,
+                0.0,
                 true);
         }
 
@@ -799,6 +811,7 @@ namespace BNKaraoke.DJ.Controls
                 AnimationClock? loopClock,
                 IReadOnlyList<DropShadowEffect> dropShadows,
                 double? initialOffset,
+                double? finalOffset,
                 bool isLooping)
             {
                 Root = root;
@@ -810,6 +823,7 @@ namespace BNKaraoke.DJ.Controls
                 _loopClock = loopClock;
                 DropShadows = dropShadows?.ToArray() ?? Array.Empty<DropShadowEffect>();
                 InitialOffset = initialOffset;
+                FinalOffset = finalOffset;
                 IsMarquee = isLooping && Transform != null && (_loopClock != null || _entryClock != null);
 
                 if (_entryClock != null)
@@ -825,6 +839,7 @@ namespace BNKaraoke.DJ.Controls
             public double LoopDurationSeconds { get; }
             public IReadOnlyList<DropShadowEffect> DropShadows { get; }
             public double? InitialOffset { get; private set; }
+            public double? FinalOffset { get; }
             public bool IsMarquee { get; }
 
             public void StartAnimation()
@@ -898,8 +913,9 @@ namespace BNKaraoke.DJ.Controls
                 }
 
                 Transform.ApplyAnimationClock(TranslateTransform.XProperty, null);
-                Transform.X = 0.0;
-                InitialOffset = 0.0;
+                var finalOffset = FinalOffset ?? 0.0;
+                Transform.X = finalOffset;
+                InitialOffset = finalOffset;
 
                 if (_loopClock != null)
                 {


### PR DESCRIPTION
## Summary
- ensure the marquee presenter keeps short text centered after the entry animation completes
- preserve the initial offset for marquee loops and expose the final offset so long messages start off-screen
- add WPF regression tests covering centered short text and marquee entry offsets

## Testing
- `dotnet test BNKaraoke_Solution/BNKaraoke.DJ.Tests/BNKaraoke.DJ.Tests.csproj` *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5127948d48323878324059f37c057