### PR TITLE
Fix marquee canvas width for scrolling long text

### DIFF
--- a/BNKaraoke.DJ/Controls/MarqueePresenter.cs
+++ b/BNKaraoke.DJ/Controls/MarqueePresenter.cs
@@ -499,6 +499,13 @@ namespace BNKaraoke.DJ.Controls
             var entryDistance = Math.Max(0.0, availableWidth);
 
             var minimumCopies = Math.Max(3, (int)Math.Ceiling((availableWidth + entryDistance) / Math.Max(1.0, segmentWidth)) + 2);
+
+            if (minimumCopies > 0 && segmentWidth > 0)
+            {
+                var totalWidth = minimumCopies * segmentWidth;
+                canvas.Width = totalWidth;
+            }
+
             var items = new List<ManualMarqueeItemDescriptor>(minimumCopies);
 
             for (var i = 0; i < minimumCopies; i++)


### PR DESCRIPTION
## Summary
- ensure the manual marquee canvas allocates visible width so long text renders

## Testing
- not run (environment missing required .NET SDK)

------
https://chatgpt.com/codex/tasks/task_e_68e53890fa4083238c65bdfc9f73973e