### PR TITLE
Ensure manual marquee items render in view immediately

### DIFF
--- a/BNKaraoke.DJ/Controls/MarqueePresenter.cs
+++ b/BNKaraoke.DJ/Controls/MarqueePresenter.cs
@@ -516,21 +516,27 @@ namespace BNKaraoke.DJ.Controls
 
             var minimumCopies = Math.Max(3, (int)Math.Ceiling((availableWidth + entryDistance) / Math.Max(1.0, segmentWidth)) + 2);
 
-            if (minimumCopies > 0 && segmentWidth > 0)
-            {
-                var totalWidth = minimumCopies * segmentWidth;
-                canvas.Width = totalWidth;
-            }
-
             var items = new List<ManualMarqueeItemDescriptor>(minimumCopies);
+
+            var startOffset = 0.0;
+            if (entryDistance > 0.0 && segmentWidth > 0.0)
+            {
+                startOffset = -Math.Min(entryDistance, segmentWidth);
+            }
 
             for (var i = 0; i < minimumCopies; i++)
             {
                 var visual = CreateTextVisual(text, dropShadows);
-                var offset = i * segmentWidth;
+                var offset = startOffset + (i * segmentWidth);
                 Canvas.SetLeft(visual, offset);
                 canvas.Children.Add(visual);
                 items.Add(new ManualMarqueeItemDescriptor(visual, offset));
+            }
+
+            if (minimumCopies > 0 && segmentWidth > 0.0)
+            {
+                var totalWidth = (minimumCopies * segmentWidth) + Math.Max(0.0, -startOffset);
+                canvas.Width = totalWidth;
             }
 
             return new ManualMarqueeBuilderResult(canvas, items);


### PR DESCRIPTION
## Summary
- offset the first manual marquee copy so long messages are visible as soon as they render
- grow the manual marquee canvas width to cover the shifted starting position while maintaining seamless scrolling

## Testing
- not run (dotnet CLI unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e58419b5608323bed76047e54e9579