### PR TITLE
Ensure blue screen bottom marquee uses brand fallback

### DIFF
--- a/BNKaraoke.DJ.Tests/OverlayViewModelTests.cs
+++ b/BNKaraoke.DJ.Tests/OverlayViewModelTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using BNKaraoke.DJ.Models;
+using BNKaraoke.DJ.Services.Overlay;
 using BNKaraoke.DJ.ViewModels.Overlays;
 using Xunit;
 
@@ -72,6 +73,26 @@ namespace BNKaraoke.DJ.Tests
             viewModel.BrandText = "   ";
 
             Assert.Equal(OverlaySettings.DefaultBrand, viewModel.BrandText);
+        }
+
+        [Fact]
+        public void BottomBandBlueTemplateUsesBrandFallbackWhenContextBrandMissing()
+        {
+            var viewModel = CreateViewModel();
+
+            viewModel.BottomTemplateBlue = "{Brand} • REQUEST A SONG AT {Brand} - Be sure to get your song request in Early !!! The song queue fills up quickly.";
+            viewModel.IsBlueState = true;
+
+            var contextField = typeof(OverlayViewModel).GetField("_templateContext", BindingFlags.Instance | BindingFlags.NonPublic);
+            var context = (OverlayTemplateContext?)contextField?.GetValue(viewModel);
+            Assert.NotNull(context);
+            context!.Brand = string.Empty;
+
+            viewModel.UpdatePlaybackState(new List<QueueEntry>(), null, null, ReorderMode.AllowMature);
+
+            Assert.Equal(
+                "BNKaraoke.com • REQUEST A SONG AT BNKaraoke.com - Be sure to get your song request in Early !!! The song queue fills up quickly.",
+                viewModel.BottomBandText);
         }
 
         private static OverlayViewModel CreateViewModel()

--- a/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
+++ b/BNKaraoke.DJ/ViewModels/Overlays/OverlayViewModel.cs
@@ -879,10 +879,35 @@ namespace BNKaraoke.DJ.ViewModels.Overlays
 
         private string RenderBottomBandText()
         {
-            var rendered = _templateEngine.Render(ActiveBottomTemplate, _templateContext);
-            if (!string.IsNullOrWhiteSpace(rendered))
+            var originalBrand = _templateContext.Brand;
+            var hasBrand = !string.IsNullOrWhiteSpace(originalBrand);
+
+            if (!hasBrand)
             {
-                return rendered;
+                var fallbackBrand = string.IsNullOrWhiteSpace(BrandText)
+                    ? OverlaySettings.DefaultBrand
+                    : BrandText.Trim();
+
+                if (!string.IsNullOrWhiteSpace(fallbackBrand))
+                {
+                    _templateContext.Brand = fallbackBrand;
+                }
+            }
+
+            try
+            {
+                var rendered = _templateEngine.Render(ActiveBottomTemplate, _templateContext);
+                if (!string.IsNullOrWhiteSpace(rendered))
+                {
+                    return rendered;
+                }
+            }
+            finally
+            {
+                if (!hasBrand)
+                {
+                    _templateContext.Brand = originalBrand;
+                }
             }
 
             return CreateBottomFallbackText();


### PR DESCRIPTION
## Summary
- ensure the overlay bottom marquee temporarily fills an empty brand with the configured brand before rendering
- add a regression test covering the blue-screen template when the brand context is missing

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e65290bb00832382e556d072786d7c