### PR TITLE
Fix overlay template engine missing token tracking build error

### DIFF
--- a/BNKaraoke.DJ/Services/Overlay/OverlayTemplateEngine.cs
+++ b/BNKaraoke.DJ/Services/Overlay/OverlayTemplateEngine.cs
@@ -63,13 +63,13 @@ namespace BNKaraoke.DJ.Services.Overlay
                 throw new ArgumentNullException(nameof(context));
             }
 
-            hadMissingTokens = false;
-
             if (string.IsNullOrWhiteSpace(template))
             {
                 hadMissingTokens = true;
                 return string.Empty;
             }
+
+            var missingTokens = false;
 
             var replaced = TokenRegex.Replace(template, match =>
             {
@@ -77,7 +77,7 @@ namespace BNKaraoke.DJ.Services.Overlay
                 var value = context.GetValue(token);
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    hadMissingTokens = true;
+                    missingTokens = true;
                     return string.Empty;
                 }
 
@@ -85,6 +85,7 @@ namespace BNKaraoke.DJ.Services.Overlay
             });
 
             replaced = MultiSpaceRegex.Replace(replaced, " ");
+            hadMissingTokens = missingTokens;
             return replaced.Trim();
         }
     }


### PR DESCRIPTION
## Summary
- avoid capturing the `hadMissingTokens` out parameter inside the replacement lambda by using a local flag
- propagate the local flag back to the out parameter after token replacement

## Testing
- not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e664ccd1888323af6f16a18ca08ae0