### PR TITLE
Fix: Blue-screen bottom marquee not displayed

### DIFF
--- a/BNKaraoke.DJ/Services/Overlay/OverlayTemplateEngine.cs
+++ b/BNKaraoke.DJ/Services/Overlay/OverlayTemplateEngine.cs
@@ -77,8 +77,9 @@ namespace BNKaraoke.DJ.Services.Overlay
                 var value = context.GetValue(token);
                 if (string.IsNullOrWhiteSpace(value))
                 {
+                    // Keep the original token text instead of erasing, so UI doesn’t look blank
                     missingTokens = true;
-                    return string.Empty;
+                    return match.Value;
                 }
 
                 return value;

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml
@@ -90,12 +90,35 @@
                   Background="{StaticResource WindowBackground}"
                   Panel.ZIndex="2"
                   HorizontalAlignment="Stretch"
-                  VerticalAlignment="Stretch">
+                  VerticalAlignment="Stretch"
+                  DataContext="{x:Static viewModels:OverlayViewModel.Instance}">
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="{Binding TopRowHeight}"/>
+                    <RowDefinition Height="{Binding CenterRowHeight}"/>
+                    <RowDefinition Height="{Binding BottomRowHeight}"/>
                 </Grid.RowDefinitions>
+
+                <!-- TOP marquee (Blue screen) -->
+                <Border Grid.Row="0"
+                        Visibility="{Binding TopBandVisibility}"
+                        Background="{Binding TopBandBrush}">
+                    <controls:MarqueePresenter Text="{Binding TopBandText}"
+                                               FontFamily="{Binding FontFamily}"
+                                               FontSize="{Binding FontSize}"
+                                               FontWeight="{Binding FontWeight}"
+                                               Foreground="{Binding FontBrush}"
+                                               StrokeEnabled="{Binding IsStrokeEnabled}"
+                                               ShadowEnabled="{Binding IsShadowEnabled}"
+                                               MarqueeEnabled="{Binding MarqueeEnabled}"
+                                               MarqueeSpeedPxPerSec="{Binding MarqueeSpeedPxPerSecond}"
+                                               SpacerWidthPx="{Binding MarqueeSpacerWidthPx}"
+                                               CrossfadeMs="{Binding MarqueeCrossfadeMs}"
+                                               Margin="0"
+                                               HorizontalAlignment="Stretch"
+                                               VerticalAlignment="Center"/>
+                </Border>
+
+                <!-- Blue overlay visuals (gradient, QR, brand) go into Grid.Row="1" -->
                 <StackPanel Grid.Row="1"
                             HorizontalAlignment="Center"
                             VerticalAlignment="Center">
@@ -111,6 +134,26 @@
                                TextWrapping="Wrap"
                                TextAlignment="Center"/>
                 </StackPanel>
+
+                <!-- BOTTOM marquee (Blue screen) -->
+                <Border Grid.Row="2"
+                        Visibility="{Binding BottomBandVisibility}"
+                        Background="{Binding BottomBandBrush}">
+                    <controls:MarqueePresenter Text="{Binding BottomBandText}"
+                                               FontFamily="{Binding FontFamily}"
+                                               FontSize="{Binding FontSize}"
+                                               FontWeight="{Binding FontWeight}"
+                                               Foreground="{Binding FontBrush}"
+                                               StrokeEnabled="{Binding IsStrokeEnabled}"
+                                               ShadowEnabled="{Binding IsShadowEnabled}"
+                                               MarqueeEnabled="{Binding MarqueeEnabled}"
+                                               MarqueeSpeedPxPerSec="{Binding MarqueeSpeedPxPerSecond}"
+                                               SpacerWidthPx="{Binding MarqueeSpacerWidthPx}"
+                                               CrossfadeMs="{Binding MarqueeCrossfadeMs}"
+                                               Margin="0"
+                                               HorizontalAlignment="Stretch"
+                                               VerticalAlignment="Center"/>
+                </Border>
             </Grid>
         </Grid>
 

--- a/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
+++ b/BNKaraoke.DJ/Views/VideoPlayerWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace BNKaraoke.DJ.Views
         private HwndSource? _windowSource;
         private IntPtr _windowHandle;
         private IntPtr _controllerWindowHandle;
+        private readonly OverlayViewModel _overlayVm = OverlayViewModel.Instance;
 
         public event EventHandler? SongEnded;
         public new event EventHandler? Closed;
@@ -418,7 +419,7 @@ namespace BNKaraoke.DJ.Views
                 CaptureControllerWindowHandle();
                 InitializeComponent();
                 RefreshEdgeGradients();
-                OverlayViewModel.Instance.IsBlueState = true;
+                _overlayVm.IsBlueState = true;
                 ShowIdleScreen();
                 SyncVideoSurfaceSize();
 
@@ -1406,7 +1407,7 @@ namespace BNKaraoke.DJ.Views
                 TitleOverlay.Visibility = Visibility.Collapsed;
                 VideoPlayer.Visibility = Visibility.Visible;
                 VideoPlayer.Opacity = 1;
-                OverlayViewModel.Instance.IsBlueState = false;
+                OnPlaybackStarted();
                 RefreshEdgeGradients();
                 SyncVideoSurfaceSize();
             }
@@ -1428,7 +1429,7 @@ namespace BNKaraoke.DJ.Views
                 TitleOverlay.Visibility = Visibility.Visible;
                 VideoPlayer.Visibility = Visibility.Collapsed;
                 VideoPlayer.Opacity = 0;
-                OverlayViewModel.Instance.IsBlueState = true;
+                OnPlaybackIdleOrPaused();
             }
 
             if (!Dispatcher.CheckAccess())
@@ -1439,6 +1440,16 @@ namespace BNKaraoke.DJ.Views
             {
                 Apply();
             }
+        }
+
+        private void OnPlaybackStarted()
+        {
+            _overlayVm.IsBlueState = false;
+        }
+
+        private void OnPlaybackIdleOrPaused()
+        {
+            _overlayVm.IsBlueState = true;
         }
 
         private void RefreshEdgeGradients()


### PR DESCRIPTION
## Summary
- bind the blue TitleOverlay rows and marquee bands to OverlayViewModel so top/bottom bands render in blue state
- centralize overlay state toggling via helpers that update OverlayViewModel.IsBlueState when playback starts or idles
- keep unresolved overlay tokens visible instead of stripping them to avoid blank marquee text

## Testing
- `dotnet build BNKaraoke.DJ/BNKaraoke.DJ.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e672c70cc08323927045ce1c82c957